### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,13 @@
         "uglify-js"     : "2.x",
         "coffee-script" : "1.2",
         "vows": "0.7.x"
+    },
+    "spm": {
+        "main": "chroma.js",
+        "ignore": [
+            "src",
+            "doc",
+            "test"
+        ]
     }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/chroma-js

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of chroma-js in spmjs, I can add it for your account after signing in http://spmjs.io.
