### PR TITLE
fix uncaught TypeError: undefined is not a function

### DIFF
--- a/chroma.js
+++ b/chroma.js
@@ -1316,7 +1316,7 @@
     if (num == null) {
       num = 7;
     }
-    if (data.values == null) {
+    if (type(data.values) !== 'array') {
       data = chroma.analyze(data);
     }
     min = data.min;


### PR DESCRIPTION
Occurs in latest Chrome and Firefox because of new Ecmascript 6 methods see http://www.sitepoint.com/preparing-ecmascript-6-new-array-methods/
In this case `data` is an array and has therefore a function "values" meaning it is no longer null.

This issue was initially reported in https://github.com/piwik/piwik/issues/6432
