### PR TITLE
Fixed typos in doc/api.md, added missing description to color.brighten()

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -128,6 +128,8 @@ chroma('red').darken().hex()  // #BC0000
 
 ### color.brighten(*amount*)
 
+Increases the lightness of the color in *Lab* color space.
+
 ```javascript
 chroma('red').brighten().hex()  // #FF603B
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -83,8 +83,8 @@ Here's what you can do with it:
 
 * [color.hex|css|rgb|hsv|hsl|lab|lch()](#colorxxx)
 * [color.alpha()](#coloralpha)
-* [color.darker()](#colordarkeramount)
-* [color.brighter()](#colorbrighteramount)
+* [color.darken()](#colordarkenamount)
+* [color.brighten()](#colorbrightenamount)
 * [color.saturate()](#colorsaturateamount)
 * [color.desaturate()](#colordesaturateamount)
 * [color.luminance()](#colorluminance)
@@ -118,7 +118,7 @@ red.alpha(0.5);
 red.css();  // rgba(255,0,0,0.5);
 ```
 
-### color.darker(*amount*)
+### color.darken(*amount*)
 
 Decreases the lightness of the color in *Lab* color space.
 
@@ -126,7 +126,7 @@ Decreases the lightness of the color in *Lab* color space.
 chroma('red').darken().hex()  // #BC0000
 ```
 
-### color.brighter(*amount*)
+### color.brighten(*amount*)
 
 ```javascript
 chroma('red').brighten().hex()  // #FF603B

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ To compile the coffee-script source files you have to run
 
 To run the tests simply run
 
-    vows test/*.coffee
+    make test
 
 
 ### Similar Libraries / Prior Art


### PR DESCRIPTION
Hey,

I noticed the outdated color.darker() and color.brigther() headings and fixed them. Also, I added a description to brighten based on the description of darken.