### PR TITLE
Feature #36 HSP color space, and color.brightness()

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -16,6 +16,7 @@ chroma([255, 0, 0]);
 chroma(0, 1, 0.5, 'hsl');
 chroma([0, 1, 0.5], 'hsl');
 chroma(0, 1, 1, 'hsv');
+chroma(0, 1, 0.55, 'hsp')
 chroma("rgb(255,0,0)");
 chroma("rgb(100%,0%,0%)");
 chroma("hsl(0,100%,50%)");
@@ -42,6 +43,7 @@ Creates a chroma.Color instance from a specific color space. Shortcut to *chroma
 chroma.rgb(255, 0, 0);
 chroma.hsl(0, 1, 0.5);
 chroma.hsv(120, 0.5, 0.5);
+chroma.hsp(120, 0.5, 0.417);
 chroma.lab(53.24, 80.09, 67.20);
 chroma.lch(53.24, 104.55, 40);
 chroma.gl(1, 0, 0);
@@ -81,13 +83,14 @@ bezInterpolator(1).hex()  // #000000
 
 Here's what you can do with it:
 
-* [color.hex|css|rgb|hsv|hsl|lab|lch()](#colorxxx)
+* [color.hex|css|rgb|hsv|hsl|hsp|lab|lch()](#colorxxx)
 * [color.alpha()](#coloralpha)
 * [color.darker()](#colordarkeramount)
 * [color.brighter()](#colorbrighteramount)
 * [color.saturate()](#colorsaturateamount)
 * [color.desaturate()](#colordesaturateamount)
 * [color.luminance()](#colorluminance)
+* [color.brightness()](#colorbrightness)
 
 ### color.*xxx*()
 
@@ -98,6 +101,7 @@ chroma('red').hex()  // "#FF0000""
 chroma('red').rgb()  // [255, 0, 0]
 chroma('red').hsv()  // [0, 1, 1]
 chroma('red').hsl()  // [0, 1, 0.5]
+chroma('red').hsp()  // [0, 1, 0.5468089245796927]
 chroma('red').lab()  // [53.2407, 80.0924, 67.2031]
 chroma('red').lch()  // [53.2407, 104.5517, 39.9990]
 chroma('red').rgba() // [255, 0, 0, 1]
@@ -158,6 +162,16 @@ chroma('white').luminance() // 1
 chroma('red').luminance() // 0.2126
 ```
 
+### color.brightness()
+
+Returns the [perceived brightness](http://alienryderflex.com/hsp.html) of the color, which is a value between 0 (black) and 0.9999999999999999 (white).
+
+```javascript
+chroma('black').brightness() // 0
+chroma('white').brightness() // 0.9999999999999999
+chroma('red').brightness() // 0.5468089245796927
+```
+
 
 # Working with color scales
 
@@ -201,6 +215,7 @@ Specify in which color space the colors should be interpolated. Defaults to "rgb
 var scale = chroma.scale(['lightyellow', 'navy']);
 scale.mode('hsv')(0.5);  // #54C08A
 scale.mode('hsl')(0.5);  // #31FF98
+scale.mode('hsp')(0.5);  // #4db07e
 scale.mode('lab')(0.5);  // #967CB2
 scale.mode('lch')(0.5);  // #D26662
 ```
@@ -287,6 +302,16 @@ Shortcut for the color.luminance()
 chroma.luminance('black') // 0
 chroma.luminance('white') // 1
 chroma.luminance('#ff0000') // 0.2126
+```
+
+## chroma.brightness
+
+Shortcut for the color.brightness()
+
+```javascript
+chroma.brightness('black') // 0
+chroma.brightness('white') // 0.9999999999999999
+chroma.brightness('#ff0000') // 0.5468089245796927
 ```
 
 ## chroma.contrast(a, b)

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -42,6 +42,9 @@ chroma.lch = (l,c,h) ->
 chroma.hsi = (h,s,i) ->
     new Color h,s,i,'hsi'
 
+chroma.hsp = (h,s,p,a) ->
+    new Color h,s,p,a,'hsp'
+
 chroma.gl = (r,g,b,a) ->
     new Color r*255,g*255,b*255,a,'gl'
 
@@ -65,6 +68,9 @@ chroma.contrast = (a, b) ->
 
 chroma.luminance = (color) ->
     chroma(color).luminance()
+
+chroma.brightness = (color) ->
+    chroma(color).brightness()
 
 
 # exposing raw classes for testing purposes

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -109,6 +109,9 @@ class Color
         else if m == 'hsi'
             me._rgb = hsi2rgb x,y,z
             me._rgb[3] = a
+        else if m == 'hsp'
+            me._rgb = hsp2rgb x,y,z
+            me._rgb[3] = a
 
         me_rgb = clip_rgb me._rgb
 
@@ -139,11 +142,17 @@ class Color
     hsi: ->
         rgb2hsi @_rgb
 
+    hsp: ->
+        rgb2hsp @_rgb
+
     gl: ->
         [@_rgb[0]/255, @_rgb[1]/255, @_rgb[2]/255, @_rgb[3]]
 
     luminance: ->
         luminance @_rgb
+
+    brightness: ->
+        brightness @_rgb
 
     name: ->
         h = @hex()

--- a/src/conversions/brightness.coffee
+++ b/src/conversions/brightness.coffee
@@ -1,0 +1,9 @@
+
+brightness = (r,g,b) ->
+    # perceived brightness based on HSP model
+    # see http://alienryderflex.com/hsp.html
+    [r,g,b] = unpack arguments
+    r /= 255
+    g /= 255
+    b /= 255
+    Math.sqrt(0.299*r*r + 0.587*g*g + 0.114*b*b)

--- a/src/conversions/hsp2rgb.coffee
+++ b/src/conversions/hsp2rgb.coffee
@@ -1,0 +1,114 @@
+Pr = 0.299
+Pg = 0.587
+Pb = 0.114
+
+hsp2rgb = () ->
+    ###
+    HSP color model
+    Code from: http://alienryderflex.com/hsp.html
+    ###
+    [h,s,p] = unpack arguments
+
+    if isNaN h
+        h = 0
+
+    h /= 360
+    minOverMax = 1 - s
+
+    if minOverMax > 0
+        if h < 1/6
+            #r > g > b
+            h *= 6
+            part = 1 + h * (1/minOverMax-1)
+
+            b = p/Math.sqrt(Pr/minOverMax/minOverMax + Pg*part*part+Pb)
+            r = b/minOverMax
+            g = b + h * (r-b)
+        else if h < 2/6
+            #g > r > b
+            h = 6 * (-h + 2/6)
+            part = 1 + h * (1/minOverMax-1)
+
+            b = p/Math.sqrt(Pg/minOverMax/minOverMax + Pr*part*part+Pb)
+            g = b/minOverMax
+            r = b + h * (g-b)
+        else if h < 3/6
+            #g > b > r
+            h = 6 * (h - 2/6)
+            part = 1 + h * (1/minOverMax-1)
+
+            r = p/Math.sqrt(Pg/minOverMax/minOverMax + Pb*part*part+Pr)
+            g = r/minOverMax
+            b = r + h * (g-r)
+        else if h < 4/6
+            #b > g > r
+            h = 6 * (-h + 4/6)
+            part = 1 + h * (1/minOverMax-1)
+
+            r = p/Math.sqrt(Pb/minOverMax/minOverMax + Pg*part*part+Pr)
+            b = r/minOverMax
+            g = r + h * (b-r)
+        else if h < 5/6
+            #b > r > g
+            h = 6 * (h - 4/6)
+            part = 1 + h * (1/minOverMax-1)
+
+            g = p/Math.sqrt(Pb/minOverMax/minOverMax + Pr*part*part+Pg)
+            b = g/minOverMax
+            r = g + h * (b-g)
+        else
+            #r > b > g
+            h = 6 * (-h + 1)
+            part = 1 + h * (1/minOverMax-1)
+
+            g = p/Math.sqrt(Pr/minOverMax/minOverMax + Pb*part*part+Pg);
+            r = g/minOverMax
+            b = g + h * (r-g)
+    else
+        if h < 1/6
+            #r > g > b
+            h *= 6
+
+            r = Math.sqrt(p*p/(Pr+Pg*h*h))
+            g = r * h
+            b = 0
+        else if h < 2/6
+            #g > r > b
+            h = 6 * (-h + 2/6)
+
+            g = Math.sqrt(p*p/(Pg+Pr*h*h))
+            r = g * h
+            b = 0
+        else if h < 3/6
+            #g > b > r
+            h = 6 * (h - 2/6)
+
+            g = Math.sqrt(p*p/(Pg+Pb*h*h))
+            b = g * h
+            r = 0
+        else if h < 4/6
+            #b > g > r
+            h = 6 * (-h + 4/6)
+
+            b = Math.sqrt(p*p/(Pb+Pg*h*h))
+            g = b * h
+            r = 0
+        else if h < 5/6
+            #b > r > g
+            h = 6 * (h - 4/6)
+
+            b = Math.sqrt(p*p/(Pb+Pr*h*h))
+            r = b * h
+            g = 0
+        else
+            #r > b > g
+            h = 6 * (-h + 1)
+
+            r = Math.sqrt(p*p/(Pr+Pb*h*h))
+            b = r * h
+            g = 0
+
+    r = Math.round(r * 255)
+    g = Math.round(g * 255)
+    b = Math.round(b * 255)
+    [r, g, b]

--- a/src/conversions/rgb2hsp.coffee
+++ b/src/conversions/rgb2hsp.coffee
@@ -1,0 +1,12 @@
+
+rgb2hsp = () ->
+    ###
+    HSP color model
+    Explanation at: http://alienryderflex.com/hsp.html
+    ###
+
+    [r,g,b,a] = unpack arguments
+    [h,s,v] = rgb2hsv r,g,b,a
+    p = brightness r,g,b,a
+
+    [h, s, p]

--- a/test/brightness-test.coffee
+++ b/test/brightness-test.coffee
@@ -1,0 +1,33 @@
+require 'es6-shim'
+vows = require 'vows'
+assert = require 'assert'
+chroma = require '../chroma'
+
+
+vows
+    .describe('Testing relative luminance')
+
+    .addBatch
+
+        'black':
+            topic: -> chroma.color 'black'
+            'lum = 0': (topic) -> assert.equal topic.brightness(), 0
+
+        'white':
+            topic: -> chroma.color 'white'
+            'lum = 1': (topic) -> assert.equal topic.brightness(), 0.9999999999999999
+
+        'red':
+            topic: -> chroma.color 'red'
+            'lum = 0.55': (topic) -> assert.equal topic.brightness(), 0.5468089245796927
+
+        'yellow brighter than blue':
+            topic: -> [chroma.color('yellow').brightness(), chroma.color('blue').brightness()]
+            'yellow > blue': (topic) -> assert topic[0] > topic[1]
+
+        'green darker than red':
+            topic: -> [chroma.color('green').brightness(), chroma.color('red').brightness()]
+            'green < red': (topic) -> assert topic[0] < topic[1]
+
+
+    .export(module)

--- a/test/hsp-test.coffee
+++ b/test/hsp-test.coffee
@@ -1,0 +1,36 @@
+require 'es6-shim'
+vows = require 'vows'
+assert = require 'assert'
+chroma = require '../chroma'
+
+
+vows
+    .describe('Testing relative luminance')
+
+    .addBatch
+
+        'red':
+            topic: chroma('red')
+            'rgb to hsp': (topic) -> assert.deepEqual topic.hsp(), [0, 1, 0.5468089245796927]
+            'hsp to rgb': (topic) -> assert.deepEqual chroma(topic.hsp(), 'hsp').rgb(), [255, 0, 0]
+
+        'azure':
+            topic: chroma('azure')
+            'rgb to hsp': (topic) -> assert.deepEqual topic.hsp(), [180, 0.058823529411764705, 0.9827808155880381]
+            'hsp to rgb': (topic) -> assert.deepEqual chroma(topic.hsp(), 'hsp').rgb(), [240, 255, 255]
+
+        'black':
+            topic: chroma('black')
+            'rgb to hsp hue': (topic) -> assert isNaN topic.hsp()[0]
+            'rgb to hsp sat': (topic) -> assert.equal topic.hsp()[1], 0
+            'rgb to hsp bri': (topic) -> assert.equal topic.hsp()[2], 0
+            'hsp to rgb': (topic) -> assert.deepEqual chroma(topic.hsp(), 'hsp').rgb(), [0, 0, 0]
+
+        'white':
+            topic: chroma('white')
+            'rgb to hsp hue': (topic) -> assert isNaN topic.hsp()[0]
+            'rgb to hsp sat': (topic) -> assert.equal topic.hsp()[1], 0
+            'rgb to hsp bri': (topic) -> assert.equal topic.hsp()[2], 0.9999999999999999
+            'hsp to rgb': (topic) -> assert.deepEqual chroma(topic.hsp(), 'hsp').rgb(), [255, 255, 255]
+
+    .export(module)


### PR DESCRIPTION
Hey,

based on [feature request #36](https://github.com/gka/chroma.js/issues/36), I implemented the HSP color space as explained in [1].
Additionally, similar to color. luminance(), I implemented color.brightness() that returns the perceived brightness P of HSP as a standalone function.

Missing: Interpolation between two colors in hsp. I wasn't sure about [these](https://github.com/gka/chroma.js/blob/master/src/color.coffee#L212-L235) lines in colors.coffee.

[1] http://alienryderflex.com/hsp.html
