### PR TITLE
Fix hex RGBA parsing

### DIFF
--- a/src/conversions/hex2rgb.coffee
+++ b/src/conversions/hex2rgb.coffee
@@ -20,7 +20,7 @@ hex2rgb = (hex) ->
         r = u >> 24 & 0xFF
         g = u >> 16 & 0xFF
         b = u >> 8 & 0xFF
-        a = u & 0xFF
+        a = Math.round((u & 0xFF) / 0xFF * 100) / 100
         return [r,g,b,a]
 
     # check for css colors, too

--- a/test/apha-test.coffee
+++ b/test/apha-test.coffee
@@ -33,6 +33,12 @@ vows
             'color is red': (topic) -> assert.equal topic.name(), 'red'
             'alpha is 50%': (topic) -> assert.equal topic.alpha(), 0.5
 
+        'parsing hex rgba colors':
+            topic: chroma '#ff00004d'
+            'color is red': (topic) -> assert.equal topic.name(), 'red'
+            'alpha is 30%': (topic) -> assert.equal topic.alpha(), 0.3
+            'rgba output': (topic) -> assert.deepEqual topic.rgba(), [255,0,0,0.3]
+
         'parsing rgba colors':
             topic: chroma.css 'rgba(255,0,0,.3)'
             'color is red': (topic) -> assert.equal topic.name(), 'red'


### PR DESCRIPTION
Before:
```js
chroma('#FF00004D').alpha(); // 77
```

After:
```js
chroma('#FF00004D').alpha(); // 0.3
```