### PR TITLE
Output Hex Values in RGBA or ARGB

### DIFF
--- a/src/color.coffee
+++ b/src/color.coffee
@@ -123,8 +123,8 @@ class Color
     rgba: ->
         @_rgb
 
-    hex: ->
-        rgb2hex @_rgb
+    hex: (mode='rgb') ->
+        rgb2hex @_rgb, mode
 
     toString: ->
         @name()
@@ -322,6 +322,3 @@ class Color
 
     desaturate: (amount=20) ->
         @saturate -amount
-
-
-

--- a/src/conversions/rgb2hex.coffee
+++ b/src/conversions/rgb2hex.coffee
@@ -4,7 +4,8 @@ rgb2hex = (channels, mode='rgb') ->
     u = r << 16 | g << 8 | b
     str = "000000" + u.toString(16) #.toUpperCase()
     str = str.substr(str.length - 6)
-    hxa = Math.round(a * 255).toString(16)
+    hxa = '0' + Math.round(a * 255).toString(16)
+    hxa = hxa.substr(hxa.length - 2)
     "#" + switch mode.toLowerCase()
           when 'rgba' then str + hxa
           when 'argb' then hxa + str

--- a/src/conversions/rgb2hex.coffee
+++ b/src/conversions/rgb2hex.coffee
@@ -1,6 +1,11 @@
 
-rgb2hex = () ->
-    [r,g,b] = unpack arguments
+rgb2hex = (channels, mode='rgb') ->
+    [r,g,b,a] = channels
     u = r << 16 | g << 8 | b
     str = "000000" + u.toString(16) #.toUpperCase()
-    "#" + str.substr(str.length - 6)
+    str = str.substr(str.length - 6)
+    hxa = Math.round(a * 255).toString(16)
+    "#" + switch mode.toLowerCase()
+          when 'rgba' then str + hxa
+          when 'argb' then hxa + str
+          else str

--- a/test/apha-test.coffee
+++ b/test/apha-test.coffee
@@ -61,4 +61,10 @@ vows
             topic: chroma.css 'hsla(0,100%,50%,0.25)'
             'cssoutput': -> (topic) -> assert.equal topic.css(), 'rgba(255,0,0,0.25)'
 
+        'hex output':
+            topic: chroma.gl 1, 0, 0, 0
+            'hex': (topic) -> assert.equal topic.hex(), '#ff0000'
+            'rgba': (topic) -> assert.equal topic.hex('rgba'), '#ff000000'
+            'argb': (topic) -> assert.equal topic.hex('argb'), '#00ff0000'
+
     .export(module)

--- a/test/colors-test.coffee
+++ b/test/colors-test.coffee
@@ -18,6 +18,8 @@ vows
             topic: chroma '#f00'
             'name': (topic) -> assert.equal topic.name(), 'red'
             'hex': (topic) -> assert.equal topic.hex(), '#ff0000'
+            'hex rgba': (topic) -> assert.equal topic.hex('rgba'), '#ff0000ff'
+            'hex argb': (topic) -> assert.equal topic.hex('argb'), '#ffff0000'
             'rgb': (topic) -> assert.deepEqual topic.rgb(), [255,0,0]
 
         'hex color, no #':


### PR DESCRIPTION
In an app I'm building, I needed to get RGBA color in hex. It seems there's [no standard for RGBA representation in hex](http://stackoverflow.com/questions/1419448/hex-representation-of-a-color-with-alpha-channel), so I've added both.

```js
var color = chroma('rgba(128,0,128,0.3)');
color.hex(); // '#800080'
color.hex('rgba'); // '#8000804d'
color.hex('argb'); // '#4d800080'
```