### PR TITLE
Use grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ m.txt
 
 .DS_Store
 license.coffee
+node_modules
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,63 @@
+"use strict";
+
+var fs = require('fs');
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    clean: [
+      'chroma.js',
+      'chroma.min.js',
+      'license.coffee',
+    ],
+    coffee: {
+      compile: {
+        options: {
+          join: true
+        },
+        files: {
+          'chroma.js': [
+            'license.coffee',
+            'src/api.coffee',
+            'src/color.coffee',
+            'src/conversions/*.coffee',
+            'src/scale.coffee',
+            'src/limits.coffee',
+            'src/colors/*.coffee',
+            'src/utils.coffee',
+            'src/interpolate.coffee',
+          ],
+        },
+      }
+    },
+    uglify: {
+      options: {
+        banner: "/*\n" + fs.readFileSync("LICENSE", {encoding: "utf8"}) + "\n*/\n",
+      },
+      my_target: {
+        files: {
+          'chroma.min.js': ['chroma.js']
+        },
+      },
+    },
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-coffee');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+
+  grunt.registerTask('license', function() {
+    var license = [
+      "###*",
+      " * @license",
+      " *",
+    ].concat(fs.readFileSync('LICENSE', {encoding: "utf8"}).split("\n").map(function(line) {
+      return " * " + line;
+    }));
+    license.push("###\n");
+    fs.writeFileSync('license.coffee', license.join("\n"));
+  });
+
+  grunt.registerTask('default', ['clean', 'license', 'coffee', 'uglify']);
+};
+

--- a/package.json
+++ b/package.json
@@ -29,8 +29,12 @@
     "test": "vows; echo"
   },
   "devDependencies": {
-    "coffee-script": "1.2",
+    "coffee-script": "1.9.2",
     "es6-shim": "^0.18.0",
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-coffee": "^0.13.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "uglify-js": "2.x",
     "vows": "0.8.x"
   },

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -43,7 +43,7 @@ chroma.hsi = (h,s,i) ->
     new Color h,s,i,'hsi'
 
 chroma.gl = (r,g,b,a) ->
-    new Color r*255,g*255,b*255,a,'gl'
+    new Color r,g,b,a,'gl'
 
 chroma.num = (n) ->
     new Color n, 'num'

--- a/test/colors-test.coffee
+++ b/test/colors-test.coffee
@@ -32,6 +32,11 @@ vows
             'hex': (topic) -> assert.equal topic.hex(), '#ff0000'
             'rgb': (topic) -> assert.deepEqual topic.rgb(), [255,0,0]
 
+        'gl color non-1':
+            topic: chroma.gl 1,0.5,0.2
+            'hex': (topic) -> assert.equal topic.hex(), '#ff7f33'
+            'rgb': (topic) -> assert.deepEqual topic.rgb(), [255,127.5,51]
+
         'gl color w/ alpha':
             topic: chroma.gl 0,0,1,0.5
             'rgba': (topic) -> assert.deepEqual topic.rgba(), [0,0,255,0.5]


### PR DESCRIPTION
Build with Grunt

I don't know if you'll like this or not but why build with Grunt?

1.  It's cross platform (works on Windows)

2.  Less global installs needed

    with make I needed make installed (I guess that's common), I also
    needed coffee install, might be the wrong version, and I needed
    uglify installed.

    With Grunt those dependencies are installed insided node_modules.

    so

        git clone git://github.com/gka/chroma.js
        npm install
        grunt

    I think you can build without installing grunt as well with

        ./node_modules/grunt/bin/grunt

Also I don't really know what you wanted this to do. If you check
the current chroma.js the license looks like

    // Generated by CoffeeScript 1.6.2
    /** echo  * @license echo  * while read i do echo  *  done echo
    */

That's fixed assuming you wanted it fixed

Take it or leave it. I just thought I'd pass it on
