### PR TITLE
Add viridis color map. Fix #76

### DIFF
--- a/src/colors/colorbrewer.coffee
+++ b/src/colors/colorbrewer.coffee
@@ -38,6 +38,7 @@ chroma.brewer = brewer =
 	PuRd: ['#f7f4f9', '#e7e1ef', '#d4b9da', '#c994c7', '#df65b0', '#e7298a', '#ce1256', '#980043', '#67001f']
 	Blues: ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b']
 	PuBuGn: ['#fff7fb', '#ece2f0', '#d0d1e6', '#a6bddb', '#67a9cf', '#3690c0', '#02818a', '#016c59', '#014636']
+	Viridis: ['#440154', '#482777', '#3f4a8a', '#31678e', '#26838f', '#1f9d8a', '#6cce5a', '#b6de2b', '#fee825']
 
 	# diverging
 


### PR DESCRIPTION
This adds the viridis colormap to the existing library of colormaps available in the chroma library.
