### PR TITLE
Returning original colors when calling colorScale.colors()

### DIFF
--- a/src/scale.coffee
+++ b/src/scale.coffee
@@ -213,6 +213,11 @@ chroma.scale = (colors, positions) ->
     f.colors = () ->
         numColors = 0
         out = 'hex'
+
+        # If no arguments are given, return the original colors that were provided
+        if arguments.length == 0
+          return _colors.map (c) -> c[out]()
+
         if arguments.length == 1
             if type(arguments[0]) == 'string'
                 out = arguments[0]
@@ -220,12 +225,12 @@ chroma.scale = (colors, positions) ->
                 numColors = arguments[0]
         if arguments.length == 2
             [numColors, out] = arguments
-        
+
         if numColors
             dm = _domain[0]
             dd = _domain[1] - dm
             return [0...numColors].map (i) -> f( dm + i/(numColors-1) * dd )[out]()
-        
+
         # returns all colors based on the defined classes
         colors = []
         samples = []
@@ -234,6 +239,7 @@ chroma.scale = (colors, positions) ->
                 samples.push (_classes[i-1]+_classes[i])*0.5
         else
             samples = _domain
+
         samples.map (v) -> f(v)[out]()
 
     f

--- a/test/scales-test.coffee
+++ b/test/scales-test.coffee
@@ -112,6 +112,11 @@ vows
             'five hex colors': (topic) -> assert.deepEqual topic.f.colors(5), ['#ffff00', '#bfd800', '#7fb100', '#3f8a00', '#006400']
             'three css colors': (topic) -> assert.deepEqual topic.f.colors(3,'css'), ['rgb(255,255,0)', 'rgb(128,178,0)', 'rgb(0,100,0)' ]
 
+        'get colors from a scale with more than two colors':
+            topic:
+                f: chroma.scale(['yellow','orange', 'darkgreen'])
+            'just origianl colors': (topic) -> assert.deepEqual topic.f.colors(), ['#ffff00', '#ffa500', '#006400']
+
         'test example in readme':
             topic: 
                 f: chroma.scale('RdYlGn')


### PR DESCRIPTION
Previously colorScale.colors() with no arguments would return the colors
that correspond to the min and max values in the domain. This changes
the behavior to return the original colors, regardless of how many
colors were used to make the scale. This symmetry will make it easier to
use a colorScale as the sole representation of the scale.

This change originated by my desire to generate a css gradient from a
colorScale. Without this change, I need to provide both the colorScale
and the colors used in the scale. With this change I can generate the
css gradient purely from the colorScale (with some other assumptions).