### PR TITLE
`scale(1)` returns the midpoint color instead of #cccccc

### DIFF
--- a/src/scale.coffee
+++ b/src/scale.coffee
@@ -227,6 +227,9 @@ chroma.scale = (colors, positions) ->
             [numColors, out] = arguments
 
         if numColors
+            if numColors == 1
+              return [f(0.5)[out]()]
+
             dm = _domain[0]
             dd = _domain[1] - dm
             return [0...numColors].map (i) -> f( dm + i/(numColors-1) * dd )[out]()

--- a/test/scales-test.coffee
+++ b/test/scales-test.coffee
@@ -116,6 +116,7 @@ vows
             topic: 
                 f: chroma.scale(['yellow','darkgreen'])
             'just colors': (topic) -> assert.deepEqual topic.f.colors(), ['#ffff00', '#006400']
+            'just one color':  (topic) -> assert.deepEqual topic.f.colors(1), ['#7fb100']
             'five hex colors': (topic) -> assert.deepEqual topic.f.colors(5), ['#ffff00', '#bfd800', '#7fb100', '#3f8a00', '#006400']
             'three css colors': (topic) -> assert.deepEqual topic.f.colors(3,'css'), ['rgb(255,255,0)', 'rgb(128,178,0)', 'rgb(0,100,0)' ]
 


### PR DESCRIPTION
This addresses #125,  assuming that the midpoint of the scale is the best value to return.

If you want me to include the grunt output, let me know!