### PR TITLE
performance: replace [].slice with Array.prototype.slice

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -20,7 +20,7 @@ limit = (x, min=0, max=1) ->
 
 unpack = (args) ->
     if args.length >= 3
-        [].slice.call args
+        Array.prototype.slice.call args
     else
         args[0]
 


### PR DESCRIPTION
This `unpack` function is used intensively throughout the library, so profiling shows these throw-away arrays create an overhead.