### PR TITLE
Remove broken undocumented method `clone`

### DIFF
--- a/src/color.coffee
+++ b/src/color.coffee
@@ -41,8 +41,5 @@ class Color
     toString: ->
         @hex()
 
-    clone: ->
-        chroma(me._rgb)
-
 
 chroma._input = _input


### PR DESCRIPTION
It references `me` from the outer (global) scope.