### PR TITLE
Fix tests to avoid error in Node.js 10

### DIFF
--- a/test/limits-test.coffee
+++ b/test/limits-test.coffee
@@ -37,7 +37,7 @@ vows
             'domain': (topic) ->
                 assert.throws () ->
                     chroma.limits topic, 'log', 4
-                , 'Logarithmic scales are only possible for values > 0'
+                , 'Logarithmic scales should only be possible for values > 0'
 
         'quantiles domain':
             topic: chroma.limits [1,2,3,4,5,10,20,100], 'quantiles', 2


### PR DESCRIPTION
This fixes an error running the tests with node 10:

```
TypeError [ERR_AMBIGUOUS_ARGUMENT]: The "error/message" argument is ambiguous. The error "Logarithmic scales are only possible for values > 0" is identical to the message. 
    at expectsError (assert.js:553:13) 
    at Function.throws (assert.js:608:3) 
    at Object.domain (/builddir/build/BUILD/package/test/limits-test.coffee:38:24) 
    at runTest (/usr/lib/node_modules/vows/lib/vows.js:136:26) 
    at EventEmitter.<anonymous> (/usr/lib/node_modules/vows/lib/vows.js:81:9) 
    at EventEmitter.emit (events.js:187:15) 
    at EventEmitter.options.Emitter.emit (/usr/lib/node_modules/vows/lib/vows.js:241:24) 
    at /usr/lib/node_modules/vows/lib/vows/suite.js:170:45 
    at process._tickCallback (internal/process/next_tick.js:61:11) 
    at Function.Module.runMain (internal/modules/cjs/loader.js:746:11) 
    at startup (internal/bootstrap/node.js:240:19) 
    at bootstrapNodeJSCore (internal/bootstrap/node.js:564:3) 
```