### PR TITLE
chroma.average and chroma.mix now use lrgb by default

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -152,7 +152,7 @@ chroma.mix('red', 'blue', 0.5, 'lch');
 
 ### chroma.average
 
-Similar to `chroma.mix(color1, color2, 'rgb')`, but works with more than two colors. Simple averaging of R,G,B components and the alpha channel.
+Similar to `chroma.mix(color1, color2, 'lrgb')`, but works with more than two colors. Simple averaging of R,G,B components and the alpha channel.
 
 ```js
 chroma.average(['white', 'yellow', 'red', 'teal']);


### PR DESCRIPTION
you’ll also need to rebuild the site so that the new defaults are visible in the API docs.