### PR TITLE
Added license attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rollup-plugin-uglify": "^6.0.0",
     "vows": "^0.8.2"
   },
+  "license" : "(BSD-3-Clause AND Apache-2.0)",
   "spm": {
     "main": "chroma.js",
     "ignore": [


### PR DESCRIPTION
added the `license` attribute to the `package.json` according to https://docs.npmjs.com/files/package.json#license, https://spdx.org/licenses/ and https://github.com/gka/chroma.js/blob/master/LICENSE

should fix #214