### PR TITLE
Update rgb2hcg.js

### DIFF
--- a/src/io/hcg/rgb2hcg.js
+++ b/src/io/hcg/rgb2hcg.js
@@ -1,12 +1,12 @@
 const {unpack} = require('../../utils');
 
 const rgb2hcg = (...args) => {
-    const [r,g,b] = unpack(args, 'rgb');
+    const [r,g,b] = unpack(args, 'rgb').map(x => x / 255);
     const min = Math.min(r, g, b);
     const max = Math.max(r, g, b);
     const delta = max - min;
-    const c = delta * 100 / 255;
-    const _g = min / (255 - delta) * 100;
+    // const c = delta;
+    const _g = min / (1 - delta);
     let h;
     if (delta === 0) {
         h = Number.NaN
@@ -17,7 +17,7 @@ const rgb2hcg = (...args) => {
         h *= 60;
         if (h < 0) h += 360
     }
-    return [h, c, _g];
+    return [h, delta, _g]; // eliminate c and just replace with delta
 }
 
 module.exports = rgb2hcg;

--- a/src/io/hcg/rgb2hcg.js
+++ b/src/io/hcg/rgb2hcg.js
@@ -5,7 +5,6 @@ const rgb2hcg = (...args) => {
     const min = Math.min(r, g, b);
     const max = Math.max(r, g, b);
     const delta = max - min;
-    // const c = delta;
     const _g = min / (1 - delta);
     let h;
     if (delta === 0) {
@@ -17,7 +16,7 @@ const rgb2hcg = (...args) => {
         h *= 60;
         if (h < 0) h += 360
     }
-    return [h, delta, _g]; // eliminate c and just replace with delta
+    return [h, delta, _g];
 }
 
 module.exports = rgb2hcg;


### PR DESCRIPTION
Reduce RGB from 0-255 to 0.0-1.0 before calculating which fixes range issues.
Change generating C and G from 0-100 to 0.0-1.0. Justification: /test/hcg2rgb.test.js uses C and G as 0.0-1.0.

Closes #250 