### PR TITLE
Make documentation's ToC sticky

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -850,6 +850,15 @@ chroma.cubehelix().lightness([0.3,0.7]);
             }
         });
 
+        function handleTocScroll(event) {
+            var tocScroll = toc.prop('scrollTop');
+            var tocHeight = toc.prop('scrollHeight') - toc.height();
+            var tocScrolled = tocScroll / tocHeight * 100;
+
+            tocScrollProgress.css('width', `${Math.floor(tocScrolled)}%`);
+        }
+
+        var tocContainer = $('<div>').addClass('toc-container')
         var toc = $('<ul />').addClass('toc');
 
         var hue = Math.random() * 360;
@@ -879,7 +888,17 @@ chroma.cubehelix().lightness([0.3,0.7]);
             el.previousElementSibling.appendChild(el);
         });
 
-        toc.appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
+        var tocScrollProgress = $('<div />')
+            .addClass('scroll-progress')
+            .appendTo($('<div />')
+                .addClass('scroll-progress-container')
+                .appendTo(toc));
+        
+        toc.scroll(handleTocScroll);
+
+        tocContainer
+            .append(toc)
+            .appendTo('.wrap');
     })(jQuery);
 </script>
 <a href="https://github.com/gka/chroma.js" class="github-corner"

--- a/docs/index.html
+++ b/docs/index.html
@@ -850,9 +850,7 @@ chroma.cubehelix().lightness([0.3,0.7]);
             }
         });
 
-        var toc = $('<ul />')
-            .addClass('toc')
-            .appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
+        var toc = $('<ul />').addClass('toc');
 
         var hue = Math.random() * 360;
         $('h2,h3').each(function () {
@@ -880,6 +878,8 @@ chroma.cubehelix().lightness([0.3,0.7]);
         $('h3+h4').each(function (i, el) {
             el.previousElementSibling.appendChild(el);
         });
+
+        toc.appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
     })(jQuery);
 </script>
 <a href="https://github.com/gka/chroma.js" class="github-corner"

--- a/docs/src/footer.inc.html
+++ b/docs/src/footer.inc.html
@@ -179,9 +179,7 @@
             }
         });
 
-        var toc = $('<ul />')
-            .addClass('toc')
-            .appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
+        var toc = $('<ul />').addClass('toc');
 
         var hue = Math.random() * 360;
         $('h2,h3').each(function () {
@@ -209,6 +207,8 @@
         $('h3+h4').each(function (i, el) {
             el.previousElementSibling.appendChild(el);
         });
+
+        toc.appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
     })(jQuery);
 </script>
 <a href="https://github.com/gka/chroma.js" class="github-corner"

--- a/docs/src/footer.inc.html
+++ b/docs/src/footer.inc.html
@@ -179,6 +179,15 @@
             }
         });
 
+        function handleTocScroll(event) {
+            var tocScroll = toc.prop('scrollTop');
+            var tocHeight = toc.prop('scrollHeight') - toc.height();
+            var tocScrolled = tocScroll / tocHeight * 100;
+
+            tocScrollProgress.css('width', `${Math.floor(tocScrolled)}%`);
+        }
+
+        var tocContainer = $('<div>').addClass('toc-container')
         var toc = $('<ul />').addClass('toc');
 
         var hue = Math.random() * 360;
@@ -208,7 +217,17 @@
             el.previousElementSibling.appendChild(el);
         });
 
-        toc.appendTo($('<div>').addClass('toc-container').appendTo('.wrap'));
+        var tocScrollProgress = $('<div />')
+            .addClass('scroll-progress')
+            .appendTo($('<div />')
+                .addClass('scroll-progress-container')
+                .appendTo(toc));
+        
+        toc.scroll(handleTocScroll);
+
+        tocContainer
+            .append(toc)
+            .appendTo('.wrap');
     })(jQuery);
 </script>
 <a href="https://github.com/gka/chroma.js" class="github-corner"

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -299,7 +299,7 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
 .cm-hidden-text {
     display:inline-block;
     width:1px;
-    // height:0px;
+    /** height:0px; **/
     opacity: 0;
     overflow:hidden;
 }

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -52,6 +52,21 @@ ul.toc {
     list-style: none;
 }
 
+ul.toc div.scroll-progress-container {
+    position: fixed;
+    top: calc(112px + 70vh);
+    display: block;
+    width: 200px;
+    height: 3px;
+    background-color: white;
+}
+
+ul.toc div.scroll-progress-container div.scroll-progress {
+    width: 0;
+    height: 100%;
+    background-color: pink;
+    border-radius: 2.5px;
+}
 
 .toc li a {
     text-decoration: none;

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -44,9 +44,11 @@ body {
 
 
 ul.toc {
-    position: absolute;
+    position: fixed;
     top: 90px;
     width: 200px;
+    height: 70vh;
+    overflow-y: scroll;
     list-style: none;
 }
 


### PR DESCRIPTION
Hey there!

I hope you weren't planning to do something similar. Yesterday, I was busy looking at `chroma.js`' documentations, and I got mildly annoyed at needing to scroll back to the very top to navigate using the table of contents lol.

So I made the table of contents position fixed, and I added a small &mdash; horizontal scroll indicator. I considered chevrons to indicate scrollability, but I figured the scroll bar itself was enough.

Let me know if you have any suggestions. My immediate idea was to also rainbow-fy the scroll indicator color (currently, it's a static pink), and maybe add some other indications to highlight the user's ability to scroll the ToC.

You can see my changes live here: https://schmannie.github.io/chroma.js/

Let me know what you think, and if you'd like to use these changes at all!