### PR TITLE
feat: support modern css colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## Changelog
 
+### 3.0.0
+* add support for modern CSS color spaces `lab()`, `lch()`, `oklab()`, `oklch()`.
+* chroma.css will no longer return legacy CSS colors like `rgb(255, 255, 0)` but modern CSS colors like `rgb(255 255 0)`.
+* you can now control the standard white reference point for the CIE Lab and CIE Lch color spaces.
+
+### 2.6.0
+* add [`color.shade()`](#color-shade), [`color.tint()`](#color-shade).
+
+### 2.5.0
+* refactored code base to ES6 modules
+
+### 2.4.0
+* add support for Oklab and Oklch color spaces
+
+### 2.3.0
+* use binom of degree n in chroma.bezier
+
+### 2.2.0
+* use Delta e2000 for chroma.deltaE #269
+
 ### 2.0.3
 * hsl2rgb will, like other x2rgb conversions now set the default alpha to 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## Changelog
 
 ### 3.0.0
-* add support for modern CSS color spaces `lab()`, `lch()`, `oklab()`, `oklch()`.
+* 🎉 NEW: add support for modern CSS color spaces `lab()`, `lch()`, `oklab()`, `oklch()`.
+* 🎉 NEW: you can now control the standard white reference point for the CIE Lab and CIE Lch color spaces.
 * chroma.css will no longer return legacy CSS colors like `rgb(255, 255, 0)` but modern CSS colors like `rgb(255 255 0)`.
-* you can now control the standard white reference point for the CIE Lab and CIE Lch color spaces.
 
 ### 2.6.0
-* add [`color.shade()`](#color-shade), [`color.tint()`](#color-shade).
+* 🎉 NEW: add [`color.shade()`](#color-shade), [`color.tint()`](#color-shade).
+* fix: remove false w3c color cornflower
 
 ### 2.5.0
 * refactored code base to ES6 modules

--- a/docs/bin/post-process
+++ b/docs/bin/post-process
@@ -6,7 +6,8 @@ const footer = fs.readFileSync('src/footer.inc.html', 'utf-8');
 
 let modifiedIndex = index.replace('</body>', '\n'+footer+'\n</body>');
 modifiedIndex = modifiedIndex.replace('</head>', '  <link rel="me" href="https://vis.social/@gka">\n</head>');
-modifiedIndex = modifiedIndex.replace('<body>', '<body><div class="wrap">');
+modifiedIndex = modifiedIndex.replace('</head>', '  <meta name="viewport" content="width=device-width, initial-scale=1.0"> \n</head>');
+modifiedIndex = modifiedIndex.replace('<body>', '<body><div class="wrap"><button class="menu-button" onclick="toggleMenu()"><span></span><span></span><span></span></button>');
 modifiedIndex = modifiedIndex.replace('</body>', '</div></body>');
 
 fs.writeFileSync('index.html', modifiedIndex);

--- a/docs/src/footer.inc.html
+++ b/docs/src/footer.inc.html
@@ -5,6 +5,16 @@
 <script type="text/javascript" src="libs/codemirror/mode/javascript/javascript.js"></script>
 
 <script type="text/javascript">
+    function toggleMenu() {
+        const menu = document.querySelector('.toc-container');
+        menu.classList.toggle('open');
+        menu.addEventListener('click', function (e) {
+            if (e.target.tagName === 'A') {
+                menu.classList.remove('open');
+            }
+        });
+    }
+
     (function ($) {
         $('code.lang-js').each(function () {
             var code = this;
@@ -16,7 +26,9 @@
                 {
                     value: code.innerHTML.trim(),
                     indentUnit: 4,
-                    mode: 'javascript'
+                    mode: 'javascript',
+                    lineWrapping: true,
+                    scrollbarStyle: 'null',
                 }
             );
 
@@ -39,7 +51,7 @@
                 //resDisplay.html('');
                 chroma.setLabWhitePoint('D65');
                 try {
-                    var s = src.split(';').map(eval);
+                    var s = src.split(';').filter(d => d).map(eval);
                     resDisplay.html(
                         '<ol><li>' +
                             s
@@ -141,16 +153,20 @@
                 }
 
                 try {
-                    var col = chroma(val),
-                        l = col.oklch()[0];
-                    span.attr(
-                        'style',
-                        [
-                            'background-color:' + col.hex(),
-                            'color:' + (l < 0.7 ? 'white' : 'black'),
-                            'opacity:' + col.alpha()
-                        ].join(';')
-                    );
+                    if (chroma.valid(val)) {
+                        const col = chroma(val);
+                        const l = col.oklch()[0];
+                        const isCSS = /[a-z]+\([^\)]+\)/.test(val)
+                        span.attr(
+                            'style',
+                            [
+                                'background-color:' + (isCSS ? val : col.hex()),
+                                'color:' + (l < 0.7 ? 'white' : 'black'),
+                                'opacity:' + col.alpha()
+                            ].join(';')
+                        );
+                        
+                    }
                 } catch (e) {
                     //console.log(e);
                     span.attr('style', '');

--- a/docs/src/footer.inc.html
+++ b/docs/src/footer.inc.html
@@ -37,15 +37,17 @@
                 // evaluate script
                 var src = cm.getDoc().getValue();
                 //resDisplay.html('');
+                chroma.setLabWhitePoint('D65');
                 try {
                     var s = src.split(';').map(eval);
                     resDisplay.html(
                         '<ol><li>' +
                             s
                                 .map(resRec)
-                                .filter(function (d) {
-                                    return d !== undefined;
-                                })
+                                .map(d => d || '&nbsp;')
+                                // .filter(function (d) {
+                                //     return d !== undefined;
+                                // })
                                 .join('</li><li>') +
                             '</li></ol>'
                     );

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -1,7 +1,7 @@
 ﻿@import 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,700';
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Roboto', "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family: -apple-system, BlinkMacSystemFont, 'Roboto', "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .wrap {
@@ -9,36 +9,44 @@ body {
     margin: 0 auto;
 }
 
-.wrap > h1, .wrap > h2, .wrap > h3, .wrap > h4, .wrap > p, .wrap > pre, .wrap > ul, .wrap > table {
+.wrap>h1,
+.wrap>h2,
+.wrap>h3,
+.wrap>h4,
+.wrap>p,
+.wrap>pre,
+.wrap>ul,
+.wrap>table {
     position: relative;
     /*left: -80px;*/
     padding-left: 300px;
 }
 
-.wrap > h2,
-.wrap > h3 {
+.wrap>h2,
+.wrap>h3 {
     padding-top: 10px;
 }
 
-.wrap > h2 a,
-.wrap > h3 a {
+.wrap>h2 a,
+.wrap>h3 a {
     color: #000;
     text-decoration: none;
 }
 
-.wrap > h2 a:hover:before,
-.wrap > h3 a:hover:before {
+.wrap>h2 a:hover:before,
+.wrap>h3 a:hover:before {
     content: '#';
     color: #ddd;
     position: absolute;
     left: 280px;
 }
 
-.wrap > ul {
+.wrap>ul {
     margin-left: 30px;
 }
 
-.wrap > p, .wrap > table {
+.wrap>p,
+.wrap>table {
     margin-right: 200px;
 }
 
@@ -47,11 +55,13 @@ table th {
     text-align: left;
     font-size: 90%;
 }
+
 table td {
     vertical-align: top;
     font-size: 90%;
 }
-table td + td {
+
+table td+td {
     padding-left: 1em;
 }
 
@@ -66,7 +76,7 @@ ul.toc {
 
 .toc li a {
     text-decoration: none;
-        margin-bottom: 5px;
+    margin-bottom: 5px;
     font-size: 13px;
     border-bottom: 1px dotted white;
     padding-bottom: 5px;
@@ -75,7 +85,7 @@ ul.toc {
 }
 
 .toc li.level-1 a {
-    margin-top: 15px;    
+    margin-top: 15px;
     font-weight: bold;
     font-size: 17px;
 }
@@ -96,25 +106,26 @@ ul.toc {
 }
 
 
-.wrap > h1 {
+.wrap>h1 {
     font-weight: 100;
     font-size: 48px;
     letter-spacing: -2px;
 }
 
-.wrap > h2 {
+.wrap>h2 {
     padding-top: 30px;
     margin-top: 20px;
 }
 
-.wrap > h3 h4 {
+.wrap>h3 h4 {
     font-weight: 400;
     display: inline-block;
     color: #999;
     margin: 0 0 0 3px;
 }
 
-.wrap p code, .wrap li code {
+.wrap p code,
+.wrap li code {
     font-size: 15px;
     margin-left: 2px;
     margin-right: 2px;
@@ -122,8 +133,8 @@ ul.toc {
 }
 
 html .cm-s-default .cm-comment {
-  color: #B3A9A9;
-  font-style: italic;
+    color: #B3A9A9;
+    font-style: italic;
 }
 
 pre {
@@ -137,21 +148,22 @@ pre .CodeMirror {
     font-size: 16px;
     line-height: 22px;
     background: #f9f9f9;
-    box-shadow: inset 2px 2px 6px rgba(0,0,0,.1);
+    box-shadow: inset 2px 2px 6px rgba(0, 0, 0, .1);
     border-radius: 10px;
     margin: -5px;
-    padding: 5px;   
+    padding: 5px;
     margin-right: 200px;
     margin-bottom: 20px;
 }
 
 
-pre .CodeMirror:hover, pre .CodeMirror:focus {
+pre .CodeMirror:hover,
+pre .CodeMirror:focus {
     background: #f6f6f0;
 }
 
 .result-display {
-    position: absolute; 
+    position: absolute;
     right: 0px;
     top: 4px;
     width: 180px;
@@ -185,15 +197,18 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
     opacity: 0.99;
     z-index: -10;
 }
+
 .result-display li {
     line-height: 24px;
 }
+
 .result-display .cm-number {
     color: #164;
 }
 
-.CodeMirror, .CodeMirror .CodeMirror-scroll {
-    overflow: visible!important;
+.CodeMirror,
+.CodeMirror .CodeMirror-scroll {
+    overflow: visible !important;
 }
 
 .CodeMirror .cm-number {
@@ -205,6 +220,7 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
     left: 50%;
     top: -15px;
 }
+
 .CodeMirror .cm-number .slider input[type="range"] {
     position: absolute;
     left: -50px;
@@ -239,8 +255,8 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
     top: 2px;
     color: #bbb;
 }
-❯
-.result-display:before {
+
+❯ .result-display:before {
     content: "RESULT";
     position: absolute;
     left: 0;
@@ -265,6 +281,7 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
     font-size: 11px;
     bottom: 3px;
 }
+
 .gradient .domain-med {
     position: absolute;
     right: 25%;
@@ -273,6 +290,7 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
     font-size: 11px;
     bottom: 3px;
 }
+
 .gradient .domain-max {
     position: absolute;
     right: 0;
@@ -293,9 +311,160 @@ pre .CodeMirror:hover, pre .CodeMirror:focus {
 }
 
 .cm-hidden-text {
-    display:inline-block;
-    width:1px;
+    display: inline-block;
+    width: 1px;
     // height:0px;
     opacity: 0;
-    overflow:hidden;
+    overflow: hidden;
+}
+
+.menu-button {
+    display: none;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+
+    .wrap>h1,
+    .wrap>h2,
+    .wrap>h3,
+    .wrap>h4,
+    .wrap>p,
+    .wrap>pre,
+    .wrap>ul,
+    .wrap>table {
+        padding-left: 0px;
+    }
+
+    .wrap>p,
+    .wrap>table,
+    pre .CodeMirror {
+        margin-right: 0px;
+    }
+
+    pre .CodeMirror {
+        font-size: 14px;
+        line-height: 20px;
+    }
+
+    .CodeMirror,
+    .CodeMirror .CodeMirror-scroll {
+        overflow: visible !important;
+    }
+
+    div.CodeMirror-scroll {
+        height: auto !important;
+        overflow: visible;
+    }
+
+    .result-display {
+        display: block;
+        position: static;
+    }
+
+    /* Base styles for the toc-container */
+    .toc-container {
+        position: relative;
+        max-width: 300px;
+        background-color: #fff;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        z-index: 1000;
+        display: none;
+        /* Hidden by default */
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 10px;
+    }
+
+    /* Menu button */
+    .menu-button {
+        border: 0;
+        background: white;
+        padding: 10px;
+        display: block;
+        position: fixed;
+        top: 10px;
+        right: 10px;
+        z-index: 10000;
+        -webkit-user-select: none;
+        user-select: none;
+    }
+
+    .github-corner {
+        display: none;
+    }
+
+    .menu-button span {
+        display: block;
+        width: 30px;
+        height: 3px;
+        margin-bottom: 5px;
+        position: relative;
+
+        background: #222222;
+        border-radius: 3px;
+
+        z-index: 1;
+
+        transform-origin: 4px 0px;
+
+        transition: transform 0.5s cubic-bezier(0.77, 0.2, 0.05, 1.0),
+            background 0.5s cubic-bezier(0.77, 0.2, 0.05, 1.0),
+            opacity 0.55s ease;
+    }
+
+    .menu-button span:first-child {
+        transform-origin: 0% 0%;
+    }
+
+    .menu-button span:nth-last-child(2) {
+        transform-origin: 0% 100%;
+    }
+
+
+    /* Show the menu when toggled */
+    .toc-container.open {
+        display: flex;
+    }
+
+    /* Styling for the toc list */
+    .toc {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+    }
+
+    .toc li {
+        padding: 8px 0;
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    .toc li a {
+        text-decoration: none;
+        font-size: 16px;
+        color: inherit;
+        /* Use the inline color style */
+    }
+
+    /* Nested menu items */
+    .level-2 {
+        padding-left: 20px;
+        /* Indent for sub-menu items */
+    }
+
+    ul.toc {
+        position: static;
+        width: auto;
+        margin-right: 20px;
+    }
+
+    .toc-container {
+        width: 70%;
+        height: 100vh;
+        position: fixed;
+        top: 0;
+        left: 0;
+        overflow-y: auto;
+    }
 }

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -9,7 +9,7 @@ body {
     margin: 0 auto;
 }
 
-.wrap > h1, .wrap > h2, .wrap > h3, .wrap > h4, .wrap > p, .wrap > pre, .wrap > ul {
+.wrap > h1, .wrap > h2, .wrap > h3, .wrap > h4, .wrap > p, .wrap > pre, .wrap > ul, .wrap > table {
     position: relative;
     /*left: -80px;*/
     padding-left: 300px;
@@ -38,8 +38,21 @@ body {
     margin-left: 30px;
 }
 
-.wrap > p {
+.wrap > p, .wrap > table {
     margin-right: 200px;
+}
+
+table th {
+    font-weight: bold;
+    text-align: left;
+    font-size: 90%;
+}
+table td {
+    vertical-align: top;
+    font-size: 90%;
+}
+table td + td {
+    padding-left: 1em;
 }
 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -572,12 +572,15 @@ chroma('#ffa505').name();
 
 ### color.css
 
+Converts the color to a CSS representation. By default chroma is using the rgb() color space, but you can pass a color space name as first argument. Accepted color spaces are `rgb`, `hsl`, `lab`, `lch`, `oklab`, and `oklch`.
+
 Returns a `RGB()` or `HSL()` string representation that can be used as CSS-color definition.
 
 ```js
 chroma('teal').css();
 chroma('teal').alpha(0.5).css();
 chroma('teal').css('hsl');
+chroma('teal').css('oklab');
 ```
 
 ### color.rgb

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,12 +114,46 @@ chroma.hsl(330, 1, 0.6)
 ### chroma.lab
 #### (Lightness, a, b)
 
-CIELAB color space
+CIE Lab color space. To calculate the lightness value of a color, the CIE Lab color space uses a reference white point. This reference white point defines what is considered to be "white" in the color space. By default chroma.js is using the D65 reference point.
 
 ```js
-chroma.lab(40,-20,50);
-chroma.lab(50,-20,50);
-chroma.lab(80,-20,50);
+chroma.lab(40, -20, 50);
+chroma.lab(50, -20, 50);
+chroma.lab(80, -20, 50);
+```
+
+### chroma.setLabWhitePoint
+#### (whitePoint)
+
+Sets the current CIE Lab white reference point. 
+
+Possible values:
+
+|  |                                                                                            |
+|-------------|-------------------------------------------------------------------------------------------------------|
+| `D50`         | Represents the color temperature of daylight at 5000K.  |
+| `D55`         | Represents mid-morning or mid-afternoon daylight at 5500K.             |
+| `D65`         | Represents average daylight at 6500K.   |
+| `A`           | Represents the color temperature of a typical incandescent light bulb at approximately 2856K.           |
+| `B`           | Represents noon daylight with a color temperature of approximately 4874K.                              |
+| `C`           | Represents average or north sky daylight; it's a theoretical construct, not often used in practical applications. |
+| `F2`          | Represents cool white fluorescent light.                                                              |
+| `F7`          | This is a broad-band fluorescent light source with a color temperature of approximately 6500K.         |
+| `F11`         | This is a narrow tri-band fluorescent light source with a color temperature of approximately 4000K.    |
+| `E`           | Represents an equal energy white point, where all wavelengths in the visible spectrum are equally represented. |
+
+```js
+chroma('hotpink').lab();
+chroma.setLabWhitePoint('F2');
+chroma('hotpink').lab();
+```
+
+### chroma.getLabWhitePoint
+
+Returns the name of the currently set CIE Lab white reference point. 
+
+```js
+chroma.getLabWhitePoint();
 ```
 
 ### chroma.oklab

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ chroma('pink').darken().saturate(2).hex()
 Aside from that, chroma.js can also help you **generate nice colors** using various methods, for instance to be [used](https://www.vis4.net/blog/posts/avoid-equidistant-hsv-colors/) in color palette for maps or data visualization.
 
 ```js
-chroma.scale(['#fafa6e','#2A4858'])
+chroma.scale(['#fafa6e', '#2A4858'])
     .mode('lch').colors(6)
 ```
 
@@ -572,15 +572,18 @@ chroma('#ffa505').name();
 
 ### color.css
 
-Converts the color to a CSS representation. By default chroma is using the rgb() color space, but you can pass a color space name as first argument. Accepted color spaces are `rgb`, `hsl`, `lab`, `lch`, `oklab`, and `oklch`.
-
-Returns a `RGB()` or `HSL()` string representation that can be used as CSS-color definition.
+Returns a CSS string representation that can be used as CSS-color definition.
 
 ```js
 chroma('teal').css();
 chroma('teal').alpha(0.5).css();
+```
+
+By default chroma is using the rgb() color space, but you can pass a color space name as first argument. Accepted color spaces are `rgb`, `hsl`, `lab`, `lch`, `oklab`, and `oklch`.
+
+```js
 chroma('teal').css('hsl');
-chroma('teal').css('oklab');
+chroma('teal').css('lab');
 ```
 
 ### color.rgb
@@ -726,7 +729,7 @@ chroma.hcl(50, 40, 100)._rgb._unclipped;
 ## color scales
 
 ### chroma.scale
-#### (colors=['white','black'])
+#### (colors=['white', 'black'])
 
 A color scale, created with `chroma.scale`, is a function that maps numeric values to a color palette. The default scale has the domain `0..1` and goes from white to black.
 
@@ -812,9 +815,9 @@ chroma.scale('YlGn').gamma(2);
 This makes sure the lightness range is spread evenly across a color scale. Especially useful when working with [multi-hue color scales](https://www.vis4.net/blog/2013/09/mastering-multi-hued-color-scales/), where simple gamma correction can't help you very much.
 
 ```js
-chroma.scale(['black','red','yellow','white']);
+chroma.scale(['black', 'red', 'yellow', 'white']);
 
-chroma.scale(['black','red','yellow','white'])
+chroma.scale(['black', 'red', 'yellow', 'white'])
     .correctLightness();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,10 @@ You can use it in node.js, too!
 
 Or you can use it in SASS using [chromatic-sass](https://github.com/bugsnag/chromatic-sass)!
 
+### Want to contribute?
+
+Come over and say hi in our [Discord channel](https://discord.gg/5pB7WgDs)!
+
 ### Build instructions
 
 First clone the repository and install the dev dependencies:

--- a/src/io/css/css2rgb.js
+++ b/src/io/css/css2rgb.js
@@ -1,16 +1,32 @@
 import hsl2rgb from '../hsl/hsl2rgb.js';
 import input from '../input.js';
 
-const RE_RGB = /^rgb\(\s*(-?\d+),\s*(-?\d+)\s*,\s*(-?\d+)\s*\)$/;
+const RE_RGB = /^rgb\(\s*(-?\d+) \s*(-?\d+)\s* \s*(-?\d+)\s*\)$/;
+const RE_RGB_LEGACY = /^rgb\(\s*(-?\d+),\s*(-?\d+)\s*,\s*(-?\d+)\s*\)$/;
+
 const RE_RGBA =
+    /^rgba?\(\s*(-?\d+) \s*(-?\d+)\s* \s*(-?\d+)\s*\/\s*([01]|[01]?\.\d+)\)$/;
+const RE_RGBA_LEGACY =
     /^rgba\(\s*(-?\d+),\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*([01]|[01]?\.\d+)\)$/;
+
 const RE_RGB_PCT =
+    /^rgb\(\s*(-?\d+(?:\.\d+)?)% \s*(-?\d+(?:\.\d+)?)%\s* \s*(-?\d+(?:\.\d+)?)%\s*\)$/;
+const RE_RGB_PCT_LEGACY =
     /^rgb\(\s*(-?\d+(?:\.\d+)?)%,\s*(-?\d+(?:\.\d+)?)%\s*,\s*(-?\d+(?:\.\d+)?)%\s*\)$/;
+
 const RE_RGBA_PCT =
+    /^rgba?\(\s*(-?\d+(?:\.\d+)?)% \s*(-?\d+(?:\.\d+)?)%\s* \s*(-?\d+(?:\.\d+)?)%\s*\/\s*([01]|[01]?\.\d+)\)$/;
+const RE_RGBA_PCT_LEGACY =
     /^rgba\(\s*(-?\d+(?:\.\d+)?)%,\s*(-?\d+(?:\.\d+)?)%\s*,\s*(-?\d+(?:\.\d+)?)%\s*,\s*([01]|[01]?\.\d+)\)$/;
+
 const RE_HSL =
+    /^hsl\(\s*(-?\d+(?:\.\d+)?)deg \s*(-?\d+(?:\.\d+)?)%\s* \s*(-?\d+(?:\.\d+)?)%\s*\)$/;
+const RE_HSL_LEGACY =
     /^hsl\(\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)%\s*,\s*(-?\d+(?:\.\d+)?)%\s*\)$/;
+
 const RE_HSLA =
+    /^hsla?\(\s*(-?\d+(?:\.\d+)?)deg \s*(-?\d+(?:\.\d+)?)%\s* \s*(-?\d+(?:\.\d+)?)%\s*\/\s*([01]|[01]?\.\d+)\)$/;
+const RE_HSLA_LEGACY =
     /^hsla\(\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)%\s*,\s*(-?\d+(?:\.\d+)?)%\s*,\s*([01]|[01]?\.\d+)\)$/;
 
 const { round } = Math;
@@ -26,8 +42,8 @@ const css2rgb = (css) => {
         } catch (e) {}
     }
 
-    // rgb(250,20,0)
-    if ((m = css.match(RE_RGB))) {
+    // rgb(250 20 0) or rgb(250,20,0)
+    if ((m = css.match(RE_RGB)) || (m = css.match(RE_RGB_LEGACY))) {
         const rgb = m.slice(1, 4);
         for (let i = 0; i < 3; i++) {
             rgb[i] = +rgb[i];
@@ -37,7 +53,7 @@ const css2rgb = (css) => {
     }
 
     // rgba(250,20,0,0.4)
-    if ((m = css.match(RE_RGBA))) {
+    if ((m = css.match(RE_RGBA)) || (m = css.match(RE_RGBA_LEGACY))) {
         const rgb = m.slice(1, 5);
         for (let i = 0; i < 4; i++) {
             rgb[i] = +rgb[i];
@@ -46,7 +62,7 @@ const css2rgb = (css) => {
     }
 
     // rgb(100%,0%,0%)
-    if ((m = css.match(RE_RGB_PCT))) {
+    if ((m = css.match(RE_RGB_PCT)) || (m = css.match(RE_RGB_PCT_LEGACY))) {
         const rgb = m.slice(1, 4);
         for (let i = 0; i < 3; i++) {
             rgb[i] = round(rgb[i] * 2.55);
@@ -56,7 +72,7 @@ const css2rgb = (css) => {
     }
 
     // rgba(100%,0%,0%,0.4)
-    if ((m = css.match(RE_RGBA_PCT))) {
+    if ((m = css.match(RE_RGBA_PCT)) || (m = css.match(RE_RGBA_PCT_LEGACY))) {
         const rgb = m.slice(1, 5);
         for (let i = 0; i < 3; i++) {
             rgb[i] = round(rgb[i] * 2.55);
@@ -66,7 +82,7 @@ const css2rgb = (css) => {
     }
 
     // hsl(0,100%,50%)
-    if ((m = css.match(RE_HSL))) {
+    if ((m = css.match(RE_HSL)) || (m = css.match(RE_HSL_LEGACY))) {
         const hsl = m.slice(1, 4);
         hsl[1] *= 0.01;
         hsl[2] *= 0.01;
@@ -79,7 +95,7 @@ const css2rgb = (css) => {
     }
 
     // hsla(0,100%,50%,0.5)
-    if ((m = css.match(RE_HSLA))) {
+    if ((m = css.match(RE_HSLA)) || (m = css.match(RE_HSLA_LEGACY))) {
         const hsl = m.slice(1, 4);
         hsl[1] *= 0.01;
         hsl[2] *= 0.01;
@@ -94,12 +110,20 @@ const css2rgb = (css) => {
 
 css2rgb.test = (s) => {
     return (
+        // modern
         RE_RGB.test(s) ||
         RE_RGBA.test(s) ||
         RE_RGB_PCT.test(s) ||
         RE_RGBA_PCT.test(s) ||
         RE_HSL.test(s) ||
-        RE_HSLA.test(s)
+        RE_HSLA.test(s) ||
+        // legacy
+        RE_RGB_LEGACY.test(s) ||
+        RE_RGBA_LEGACY.test(s) ||
+        RE_RGB_PCT_LEGACY.test(s) ||
+        RE_RGBA_PCT_LEGACY.test(s) ||
+        RE_HSL_LEGACY.test(s) ||
+        RE_HSLA_LEGACY.test(s)
     );
 };
 

--- a/src/io/css/hsl2css.js
+++ b/src/io/css/hsl2css.js
@@ -21,7 +21,7 @@ const hsl2css = (...args) => {
     } else {
         hsla.length = 3;
     }
-    return `${mode}(${hsla.join(' ')})`;
+    return `${mode.substr(0, 3)}(${hsla.join(' ')})`;
 };
 
 export default hsl2css;

--- a/src/io/css/hsl2css.js
+++ b/src/io/css/hsl2css.js
@@ -12,16 +12,16 @@ const rnd = (a) => Math.round(a * 100) / 100;
 const hsl2css = (...args) => {
     const hsla = unpack(args, 'hsla');
     let mode = last(args) || 'lsa';
-    hsla[0] = rnd(hsla[0] || 0);
+    hsla[0] = rnd(hsla[0] || 0) + 'deg';
     hsla[1] = rnd(hsla[1] * 100) + '%';
     hsla[2] = rnd(hsla[2] * 100) + '%';
     if (mode === 'hsla' || (hsla.length > 3 && hsla[3] < 1)) {
-        hsla[3] = hsla.length > 3 ? hsla[3] : 1;
+        hsla[3] = '/ ' + (hsla.length > 3 ? hsla[3] : 1);
         mode = 'hsla';
     } else {
         hsla.length = 3;
     }
-    return `${mode}(${hsla.join(',')})`;
+    return `${mode}(${hsla.join(' ')})`;
 };
 
 export default hsl2css;

--- a/src/io/css/lab2css.js
+++ b/src/io/css/lab2css.js
@@ -1,0 +1,25 @@
+import { unpack, last } from '../../utils/index.js';
+const rnd = (a) => Math.round(a * 100) / 100;
+
+/*
+ * supported arguments:
+ * - lab2css(l,a,b)
+ * - lab2css(l,a,b,alpha)
+ * - lab2css([l,a,b], mode)
+ * - lab2css([l,a,b,alpha], mode)
+ */
+const lab2css = (...args) => {
+    const laba = unpack(args, 'lab');
+    let mode = last(args) || 'lab';
+    laba[0] = rnd(laba[0]) + '%';
+    laba[1] = rnd(laba[1]);
+    laba[2] = rnd(laba[2]);
+    if (mode === 'laba' || (laba.length > 3 && laba[3] < 1)) {
+        laba[3] = '/' + (laba.length > 3 ? laba[3] : 1);
+    } else {
+        laba.length = 3;
+    }
+    return `lab(${laba.join(' ')})`;
+};
+
+export default lab2css;

--- a/src/io/css/lab2css.js
+++ b/src/io/css/lab2css.js
@@ -15,7 +15,7 @@ const lab2css = (...args) => {
     laba[1] = rnd(laba[1]);
     laba[2] = rnd(laba[2]);
     if (mode === 'laba' || (laba.length > 3 && laba[3] < 1)) {
-        laba[3] = '/' + (laba.length > 3 ? laba[3] : 1);
+        laba[3] = '/ ' + (laba.length > 3 ? laba[3] : 1);
     } else {
         laba.length = 3;
     }

--- a/src/io/css/lch2css.js
+++ b/src/io/css/lch2css.js
@@ -1,0 +1,25 @@
+import { unpack, last } from '../../utils/index.js';
+const rnd = (a) => Math.round(a * 100) / 100;
+
+/*
+ * supported arguments:
+ * - lab2css(l,a,b)
+ * - lab2css(l,a,b,alpha)
+ * - lab2css([l,a,b], mode)
+ * - lab2css([l,a,b,alpha], mode)
+ */
+const lch2css = (...args) => {
+    const lcha = unpack(args, 'lch');
+    let mode = last(args) || 'lab';
+    lcha[0] = rnd(lcha[0]) + '%';
+    lcha[1] = rnd(lcha[1]);
+    lcha[2] = rnd(lcha[2]) + 'deg'; // add deg unit to hue
+    if (mode === 'lcha' || (lcha.length > 3 && lcha[3] < 1)) {
+        lcha[3] = '/ ' + (lcha.length > 3 ? lcha[3] : 1);
+    } else {
+        lcha.length = 3;
+    }
+    return `lch(${lcha.join(' ')})`;
+};
+
+export default lch2css;

--- a/src/io/css/oklab2css.js
+++ b/src/io/css/oklab2css.js
@@ -1,0 +1,17 @@
+import { unpack } from '../../utils/index.js';
+const rnd = (a) => Math.round(a * 100) / 100;
+
+const oklab2css = (...args) => {
+    const laba = unpack(args, 'lab');
+    laba[0] = rnd(laba[0] * 100) + '%';
+    laba[1] = rnd(laba[1]);
+    laba[2] = rnd(laba[2]);
+    if (laba.length > 3 && laba[3] < 1) {
+        laba[3] = '/ ' + (laba.length > 3 ? laba[3] : 1);
+    } else {
+        laba.length = 3;
+    }
+    return `oklab(${laba.join(' ')})`;
+};
+
+export default oklab2css;

--- a/src/io/css/oklch2css.js
+++ b/src/io/css/oklch2css.js
@@ -1,0 +1,17 @@
+import { unpack } from '../../utils/index.js';
+const rnd = (a) => Math.round(a * 100) / 100;
+
+const oklab2css = (...args) => {
+    const laba = unpack(args, 'lab');
+    laba[0] = rnd(laba[0] * 100) + '%';
+    laba[1] = rnd(laba[1]);
+    laba[2] = rnd(laba[2]) + 'deg';
+    if (laba.length > 3 && laba[3] < 1) {
+        laba[3] = '/ ' + (laba.length > 3 ? laba[3] : 1);
+    } else {
+        laba.length = 3;
+    }
+    return `oklch(${laba.join(' ')})`;
+};
+
+export default oklab2css;

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -3,6 +3,7 @@ import hsl2css from './hsl2css.js';
 import rgb2hsl from '../hsl/rgb2hsl.js';
 import lab2css from './lab2css.js';
 import rgb2lab from '../lab/rgb2lab.js';
+import { getLabWhitePoint, setLabWhitePoint } from '../lab/lab-constants.js';
 const { round } = Math;
 
 /*
@@ -20,7 +21,12 @@ const rgb2css = (...args) => {
         return hsl2css(rgb2hsl(rgba), mode);
     }
     if (mode.substr(0, 3) == 'lab') {
-        return lab2css(rgb2lab(rgba), mode);
+        // change to D50 lab whitepoint since this is what W3C is using for CSS Lab colors
+        const prevWhitePoint = getLabWhitePoint();
+        setLabWhitePoint('d50');
+        const cssColor = lab2css(rgb2lab(rgba), mode);
+        setLabWhitePoint(prevWhitePoint);
+        return cssColor;
     }
     rgba[0] = round(rgba[0]);
     rgba[1] = round(rgba[1]);

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -21,10 +21,10 @@ const rgb2css = (...args) => {
     rgba[1] = round(rgba[1]);
     rgba[2] = round(rgba[2]);
     if (mode === 'rgba' || (rgba.length > 3 && rgba[3] < 1)) {
-        rgba[3] = rgba.length > 3 ? rgba[3] : 1;
+        rgba[3] = '/ ' + (rgba.length > 3 ? rgba[3] : 1);
         mode = 'rgba';
     }
-    return `${mode}(${rgba.slice(0, mode === 'rgb' ? 3 : 4).join(',')})`;
+    return `${mode}(${rgba.slice(0, mode === 'rgb' ? 3 : 4).join(' ')})`;
 };
 
 export default rgb2css;

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -1,6 +1,8 @@
 import { unpack, last } from '../../utils/index.js';
 import hsl2css from './hsl2css.js';
 import rgb2hsl from '../hsl/rgb2hsl.js';
+import lab2css from './lab2css.js';
+import rgb2lab from '../lab/rgb2lab.js';
 const { round } = Math;
 
 /*
@@ -16,6 +18,9 @@ const rgb2css = (...args) => {
     let mode = last(args) || 'rgb';
     if (mode.substr(0, 3) == 'hsl') {
         return hsl2css(rgb2hsl(rgba), mode);
+    }
+    if (mode.substr(0, 3) == 'lab') {
+        return lab2css(rgb2lab(rgba), mode);
     }
     rgba[0] = round(rgba[0]);
     rgba[1] = round(rgba[1]);

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -3,6 +3,8 @@ import hsl2css from './hsl2css.js';
 import rgb2hsl from '../hsl/rgb2hsl.js';
 import lab2css from './lab2css.js';
 import rgb2lab from '../lab/rgb2lab.js';
+import lch2css from './lch2css.js';
+import rgb2lch from '../lch/rgb2lch.js';
 import { getLabWhitePoint, setLabWhitePoint } from '../lab/lab-constants.js';
 const { round } = Math;
 
@@ -25,6 +27,14 @@ const rgb2css = (...args) => {
         const prevWhitePoint = getLabWhitePoint();
         setLabWhitePoint('d50');
         const cssColor = lab2css(rgb2lab(rgba), mode);
+        setLabWhitePoint(prevWhitePoint);
+        return cssColor;
+    }
+    if (mode.substr(0, 3) == 'lch') {
+        // change to D50 lab whitepoint since this is what W3C is using for CSS Lab colors
+        const prevWhitePoint = getLabWhitePoint();
+        setLabWhitePoint('d50');
+        const cssColor = lch2css(rgb2lch(rgba), mode);
         setLabWhitePoint(prevWhitePoint);
         return cssColor;
     }

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -29,7 +29,7 @@ const rgb2css = (...args) => {
         rgba[3] = '/ ' + (rgba.length > 3 ? rgba[3] : 1);
         mode = 'rgba';
     }
-    return `${mode}(${rgba.slice(0, mode === 'rgb' ? 3 : 4).join(' ')})`;
+    return `${mode.substr(0, 3)}(${rgba.slice(0, mode === 'rgb' ? 3 : 4).join(' ')})`;
 };
 
 export default rgb2css;

--- a/src/io/css/rgb2css.js
+++ b/src/io/css/rgb2css.js
@@ -5,6 +5,10 @@ import lab2css from './lab2css.js';
 import rgb2lab from '../lab/rgb2lab.js';
 import lch2css from './lch2css.js';
 import rgb2lch from '../lch/rgb2lch.js';
+import rgb2oklab from '../oklab/rgb2oklab.js';
+import oklab2css from './oklab2css.js';
+import rgb2oklch from '../oklch/rgb2oklch.js';
+import oklch2css from './oklch2css.js';
 import { getLabWhitePoint, setLabWhitePoint } from '../lab/lab-constants.js';
 const { round } = Math;
 
@@ -19,10 +23,10 @@ const { round } = Math;
 const rgb2css = (...args) => {
     const rgba = unpack(args, 'rgba');
     let mode = last(args) || 'rgb';
-    if (mode.substr(0, 3) == 'hsl') {
+    if (mode.substr(0, 3) === 'hsl') {
         return hsl2css(rgb2hsl(rgba), mode);
     }
-    if (mode.substr(0, 3) == 'lab') {
+    if (mode.substr(0, 3) === 'lab') {
         // change to D50 lab whitepoint since this is what W3C is using for CSS Lab colors
         const prevWhitePoint = getLabWhitePoint();
         setLabWhitePoint('d50');
@@ -30,13 +34,19 @@ const rgb2css = (...args) => {
         setLabWhitePoint(prevWhitePoint);
         return cssColor;
     }
-    if (mode.substr(0, 3) == 'lch') {
+    if (mode.substr(0, 3) === 'lch') {
         // change to D50 lab whitepoint since this is what W3C is using for CSS Lab colors
         const prevWhitePoint = getLabWhitePoint();
         setLabWhitePoint('d50');
         const cssColor = lch2css(rgb2lch(rgba), mode);
         setLabWhitePoint(prevWhitePoint);
         return cssColor;
+    }
+    if (mode.substr(0, 5) === 'oklab') {
+        return oklab2css(rgb2oklab(rgba));
+    }
+    if (mode.substr(0, 5) === 'oklch') {
+        return oklch2css(rgb2oklch(rgba));
     }
     rgba[0] = round(rgba[0]);
     rgba[1] = round(rgba[1]);

--- a/src/io/lab/index.js
+++ b/src/io/lab/index.js
@@ -4,12 +4,15 @@ import Color from '../../Color.js';
 import input from '../input.js';
 import lab2rgb from './lab2rgb.js';
 import rgb2lab from './rgb2lab.js';
+import { getLabWhitePoint, setLabWhitePoint } from './lab-constants.js';
 
 Color.prototype.lab = function () {
     return rgb2lab(this._rgb);
 };
 
 chroma.lab = (...args) => new Color(...args, 'lab');
+chroma.setLabWhitePoint = setLabWhitePoint;
+chroma.getLabWhitePoint = getLabWhitePoint;
 
 input.format.lab = lab2rgb;
 

--- a/src/io/lab/lab-constants.js
+++ b/src/io/lab/lab-constants.js
@@ -1,8 +1,9 @@
-export default {
+const labConstants = {
     // Corresponds roughly to RGB brighter/darker
     Kn: 18,
 
     // D65 standard referent
+    labWhitePoint: 'd65',
     Xn: 0.95047,
     Yn: 1,
     Zn: 1.08883,
@@ -10,5 +11,110 @@ export default {
     t0: 0.137931034, // 4 / 29
     t1: 0.206896552, // 6 / 29
     t2: 0.12841855, // 3 * t1 * t1
-    t3: 0.008856452 // t1 * t1 * t1
+    t3: 0.008856452, // t1 * t1 * t1,
+
+    kE: 216.0 / 24389.0,
+    kKE: 8.0,
+    kK: 24389.0 / 27.0,
+
+    RefWhiteRGB: {
+        // sRGB
+        X: 0.95047,
+        Y: 1,
+        Z: 1.08883
+    },
+
+    MtxRGB2XYZ: {
+        m00: 0.4124564390896922,
+        m01: 0.21267285140562253,
+        m02: 0.0193338955823293,
+        m10: 0.357576077643909,
+        m11: 0.715152155287818,
+        m12: 0.11919202588130297,
+        m20: 0.18043748326639894,
+        m21: 0.07217499330655958,
+        m22: 0.9503040785363679
+    },
+
+    MtxXYZ2RGB: {
+        m00: 3.2404541621141045,
+        m01: -0.9692660305051868,
+        m02: 0.055643430959114726,
+        m10: -1.5371385127977166,
+        m11: 1.8760108454466942,
+        m12: -0.2040259135167538,
+        m20: -0.498531409556016,
+        m21: 0.041556017530349834,
+        m22: 1.0572251882231791
+    },
+
+    // used in rgb2xyz
+    As: 0.9414285350000001,
+    Bs: 1.040417467,
+    Cs: 1.089532651,
+
+    MtxAdaptMa: {
+        m00: 0.8951,
+        m01: -0.7502,
+        m02: 0.0389,
+        m10: 0.2664,
+        m11: 1.7135,
+        m12: -0.0685,
+        m20: -0.1614,
+        m21: 0.0367,
+        m22: 1.0296
+    },
+
+    MtxAdaptMaI: {
+        m00: 0.9869929054667123,
+        m01: 0.43230526972339456,
+        m02: -0.008528664575177328,
+        m10: -0.14705425642099013,
+        m11: 0.5183602715367776,
+        m12: 0.04004282165408487,
+        m20: 0.15996265166373125,
+        m21: 0.0492912282128556,
+        m22: 0.9684866957875502
+    }
 };
+
+export default labConstants;
+
+// taken from https://de.mathworks.com/help/images/ref/whitepoint.html
+const ILLUMINANTS = new Map([
+    // ASTM E308-01
+    ['a', [1.0985, 0.35585]],
+    // Wyszecki & Stiles, p. 769
+    ['b', [1.0985, 0.35585]],
+    // C ASTM E308-01
+    ['c', [0.98074, 1.18232]],
+    // D50 (ASTM E308-01)
+    ['d50', [0.96422, 0.82521]],
+    // D55 (ASTM E308-01)
+    ['d55', [0.95682, 0.92149]],
+    // D65 (ASTM E308-01)
+    ['d65', [0.95047, 1.08883]],
+    // E (ASTM E308-01)
+    ['e', [1, 1, 1]],
+    // F2 (ASTM E308-01)
+    ['f2', [0.99186, 0.67393]],
+    // F7 (ASTM E308-01)
+    ['f7', [0.95041, 1.08747]],
+    // F11 (ASTM E308-01)
+    ['f11', [1.00962, 0.6435]],
+    ['icc', [0.96422, 0.82521]]
+]);
+
+export function setLabWhitePoint(name) {
+    const ill = ILLUMINANTS.get(String(name).toLowerCase());
+    if (!ill) {
+        throw new Error('unknown Lab illuminant ' + name);
+    }
+    labConstants.labWhitePoint = name;
+    labConstants.Xn = ill[0];
+    labConstants.Zn = ill[1];
+}
+
+export function getLabWhitePoint() {
+    return labConstants.labWhitePoint;
+}

--- a/src/io/lab/lab2rgb.js
+++ b/src/io/lab/lab2rgb.js
@@ -1,6 +1,5 @@
 import LAB_CONSTANTS from './lab-constants.js';
 import { unpack } from '../../utils/index.js';
-const { pow } = Math;
 
 /*
  * L* [0..100]
@@ -9,32 +8,93 @@ const { pow } = Math;
  */
 const lab2rgb = (...args) => {
     args = unpack(args, 'lab');
-    const [l, a, b] = args;
-    let x, y, z, r, g, b_;
-
-    y = (l + 16) / 116;
-    x = isNaN(a) ? y : y + a / 500;
-    z = isNaN(b) ? y : y - b / 200;
-
-    y = LAB_CONSTANTS.Yn * lab_xyz(y);
-    x = LAB_CONSTANTS.Xn * lab_xyz(x);
-    z = LAB_CONSTANTS.Zn * lab_xyz(z);
-
-    r = xyz_rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z); // D65 -> sRGB
-    g = xyz_rgb(-0.969266 * x + 1.8760108 * y + 0.041556 * z);
-    b_ = xyz_rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z);
-
+    const [L, a, b] = args;
+    const [x, y, z] = lab2xyz(L, a, b);
+    const [r, g, b_] = xyz2rgb(x, y, z);
     return [r, g, b_, args.length > 3 ? args[3] : 1];
 };
 
-const xyz_rgb = (r) => {
-    return 255 * (r <= 0.00304 ? 12.92 * r : 1.055 * pow(r, 1 / 2.4) - 0.055);
+const lab2xyz = (L, a, b) => {
+    const { kE, kK, kKE, Xn, Yn, Zn } = LAB_CONSTANTS;
+
+    const fy = (L + 16.0) / 116.0;
+    const fx = 0.002 * a + fy;
+    const fz = fy - 0.005 * b;
+
+    const fx3 = fx * fx * fx;
+    const fz3 = fz * fz * fz;
+
+    const xr = fx3 > kE ? fx3 : (116.0 * fx - 16.0) / kK;
+    const yr = L > kKE ? Math.pow((L + 16.0) / 116.0, 3.0) : L / kK;
+    const zr = fz3 > kE ? fz3 : (116.0 * fz - 16.0) / kK;
+
+    const x = xr * Xn;
+    const y = yr * Yn;
+    const z = zr * Zn;
+
+    return [x, y, z];
 };
 
-const lab_xyz = (t) => {
-    return t > LAB_CONSTANTS.t1
-        ? t * t * t
-        : LAB_CONSTANTS.t2 * (t - LAB_CONSTANTS.t0);
+const compand = (linear) => {
+    /* sRGB */
+    const sign = Math.sign(linear);
+    linear = Math.abs(linear);
+    return (
+        (linear <= 0.0031308
+            ? linear * 12.92
+            : 1.055 * Math.pow(linear, 1.0 / 2.4) - 0.055) * sign
+    );
+};
+
+const xyz2rgb = (x, y, z) => {
+    const { MtxAdaptMa, MtxAdaptMaI, MtxXYZ2RGB, RefWhiteRGB, Xn, Yn, Zn } =
+        LAB_CONSTANTS;
+
+    const As = Xn * MtxAdaptMa.m00 + Yn * MtxAdaptMa.m10 + Zn * MtxAdaptMa.m20;
+    const Bs = Xn * MtxAdaptMa.m01 + Yn * MtxAdaptMa.m11 + Zn * MtxAdaptMa.m21;
+    const Cs = Xn * MtxAdaptMa.m02 + Yn * MtxAdaptMa.m12 + Zn * MtxAdaptMa.m22;
+
+    const Ad =
+        RefWhiteRGB.X * MtxAdaptMa.m00 +
+        RefWhiteRGB.Y * MtxAdaptMa.m10 +
+        RefWhiteRGB.Z * MtxAdaptMa.m20;
+    const Bd =
+        RefWhiteRGB.X * MtxAdaptMa.m01 +
+        RefWhiteRGB.Y * MtxAdaptMa.m11 +
+        RefWhiteRGB.Z * MtxAdaptMa.m21;
+    const Cd =
+        RefWhiteRGB.X * MtxAdaptMa.m02 +
+        RefWhiteRGB.Y * MtxAdaptMa.m12 +
+        RefWhiteRGB.Z * MtxAdaptMa.m22;
+
+    const X1 =
+        (x * MtxAdaptMa.m00 + y * MtxAdaptMa.m10 + z * MtxAdaptMa.m20) *
+        (Ad / As);
+    const Y1 =
+        (x * MtxAdaptMa.m01 + y * MtxAdaptMa.m11 + z * MtxAdaptMa.m21) *
+        (Bd / Bs);
+    const Z1 =
+        (x * MtxAdaptMa.m02 + y * MtxAdaptMa.m12 + z * MtxAdaptMa.m22) *
+        (Cd / Cs);
+
+    const X2 =
+        X1 * MtxAdaptMaI.m00 + Y1 * MtxAdaptMaI.m10 + Z1 * MtxAdaptMaI.m20;
+    const Y2 =
+        X1 * MtxAdaptMaI.m01 + Y1 * MtxAdaptMaI.m11 + Z1 * MtxAdaptMaI.m21;
+    const Z2 =
+        X1 * MtxAdaptMaI.m02 + Y1 * MtxAdaptMaI.m12 + Z1 * MtxAdaptMaI.m22;
+
+    const r = compand(
+        X2 * MtxXYZ2RGB.m00 + Y2 * MtxXYZ2RGB.m10 + Z2 * MtxXYZ2RGB.m20
+    );
+    const g = compand(
+        X2 * MtxXYZ2RGB.m01 + Y2 * MtxXYZ2RGB.m11 + Z2 * MtxXYZ2RGB.m21
+    );
+    const b = compand(
+        X2 * MtxXYZ2RGB.m02 + Y2 * MtxXYZ2RGB.m12 + Z2 * MtxXYZ2RGB.m22
+    );
+
+    return [r * 255, g * 255, b * 255];
 };
 
 export default lab2rgb;

--- a/src/io/lab/rgb2lab.js
+++ b/src/io/lab/rgb2lab.js
@@ -1,37 +1,64 @@
 import LAB_CONSTANTS from './lab-constants.js';
 import { unpack } from '../../utils/index.js';
-const { pow } = Math;
 
 const rgb2lab = (...args) => {
     const [r, g, b] = unpack(args, 'rgb');
     const [x, y, z] = rgb2xyz(r, g, b);
-    const l = 116 * y - 16;
-    return [l < 0 ? 0 : l, 500 * (x - y), 200 * (y - z)];
+    return xyz2lab(x, y, z);
 };
 
-const rgb_xyz = (r) => {
-    if ((r /= 255) <= 0.04045) return r / 12.92;
-    return pow((r + 0.055) / 1.055, 2.4);
-};
+function xyz2lab(x, y, z) {
+    const { Xn, Yn, Zn, kE, kK } = LAB_CONSTANTS;
+    const xr = x / Xn;
+    const yr = y / Yn;
+    const zr = z / Zn;
 
-const xyz_lab = (t) => {
-    if (t > LAB_CONSTANTS.t3) return pow(t, 1 / 3);
-    return t / LAB_CONSTANTS.t2 + LAB_CONSTANTS.t0;
-};
+    const fx = xr > kE ? Math.pow(xr, 1.0 / 3.0) : (kK * xr + 16.0) / 116.0;
+    const fy = yr > kE ? Math.pow(yr, 1.0 / 3.0) : (kK * yr + 16.0) / 116.0;
+    const fz = zr > kE ? Math.pow(zr, 1.0 / 3.0) : (kK * zr + 16.0) / 116.0;
+
+    return [116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz)];
+}
+
+function gammaAdjustSRGB(companded) {
+    const sign = Math.sign(companded);
+    companded = Math.abs(companded);
+    const linear =
+        companded <= 0.04045
+            ? companded / 12.92
+            : Math.pow((companded + 0.055) / 1.055, 2.4);
+    return linear * sign;
+}
 
 const rgb2xyz = (r, g, b) => {
-    r = rgb_xyz(r);
-    g = rgb_xyz(g);
-    b = rgb_xyz(b);
-    const x = xyz_lab(
-        (0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / LAB_CONSTANTS.Xn
-    );
-    const y = xyz_lab(
-        (0.2126729 * r + 0.7151522 * g + 0.072175 * b) / LAB_CONSTANTS.Yn
-    );
-    const z = xyz_lab(
-        (0.0193339 * r + 0.119192 * g + 0.9503041 * b) / LAB_CONSTANTS.Zn
-    );
+    // normalize and gamma adjust
+    r = gammaAdjustSRGB(r / 255);
+    g = gammaAdjustSRGB(g / 255);
+    b = gammaAdjustSRGB(b / 255);
+
+    const { MtxRGB2XYZ, MtxAdaptMa, MtxAdaptMaI, Xn, Yn, Zn, As, Bs, Cs } =
+        LAB_CONSTANTS;
+
+    let x = r * MtxRGB2XYZ.m00 + g * MtxRGB2XYZ.m10 + b * MtxRGB2XYZ.m20;
+    let y = r * MtxRGB2XYZ.m01 + g * MtxRGB2XYZ.m11 + b * MtxRGB2XYZ.m21;
+    let z = r * MtxRGB2XYZ.m02 + g * MtxRGB2XYZ.m12 + b * MtxRGB2XYZ.m22;
+
+    const Ad = Xn * MtxAdaptMa.m00 + Yn * MtxAdaptMa.m10 + Zn * MtxAdaptMa.m20;
+    const Bd = Xn * MtxAdaptMa.m01 + Yn * MtxAdaptMa.m11 + Zn * MtxAdaptMa.m21;
+    const Cd = Xn * MtxAdaptMa.m02 + Yn * MtxAdaptMa.m12 + Zn * MtxAdaptMa.m22;
+
+    let X = x * MtxAdaptMa.m00 + y * MtxAdaptMa.m10 + z * MtxAdaptMa.m20;
+    let Y = x * MtxAdaptMa.m01 + y * MtxAdaptMa.m11 + z * MtxAdaptMa.m21;
+    let Z = x * MtxAdaptMa.m02 + y * MtxAdaptMa.m12 + z * MtxAdaptMa.m22;
+
+    X *= Ad / As;
+    Y *= Bd / Bs;
+    Z *= Cd / Cs;
+
+    x = X * MtxAdaptMaI.m00 + Y * MtxAdaptMaI.m10 + Z * MtxAdaptMaI.m20;
+    y = X * MtxAdaptMaI.m01 + Y * MtxAdaptMaI.m11 + Z * MtxAdaptMaI.m21;
+    z = X * MtxAdaptMaI.m02 + Y * MtxAdaptMaI.m12 + Z * MtxAdaptMaI.m22;
+
     return [x, y, z];
 };
 

--- a/src/io/lab/rgb2lab.js
+++ b/src/io/lab/rgb2lab.js
@@ -2,9 +2,10 @@ import LAB_CONSTANTS from './lab-constants.js';
 import { unpack } from '../../utils/index.js';
 
 const rgb2lab = (...args) => {
-    const [r, g, b] = unpack(args, 'rgb');
+    const [r, g, b, ...rest] = unpack(args, 'rgb');
     const [x, y, z] = rgb2xyz(r, g, b);
-    return xyz2lab(x, y, z);
+    const [L, a, b_] = xyz2lab(x, y, z);
+    return [L, a, b_, ...(rest.length > 0 && rest[0] < 1 ? [rest[0]] : [])];
 };
 
 function xyz2lab(x, y, z) {

--- a/src/io/lch/rgb2lch.js
+++ b/src/io/lch/rgb2lch.js
@@ -3,9 +3,10 @@ import rgb2lab from '../lab/rgb2lab.js';
 import lab2lch from './lab2lch.js';
 
 const rgb2lch = (...args) => {
-    const [r, g, b] = unpack(args, 'rgb');
+    const [r, g, b, ...rest] = unpack(args, 'rgb');
     const [l, a, b_] = rgb2lab(r, g, b);
-    return lab2lch(l, a, b_);
+    const [L, c, h] = lab2lch(l, a, b_);
+    return [L, c, h, ...(rest.length > 0 && rest[0] < 1 ? [rest[0]] : [])];
 };
 
 export default rgb2lch;

--- a/src/io/oklab/rgb2oklab.js
+++ b/src/io/oklab/rgb2oklab.js
@@ -4,7 +4,7 @@ const { cbrt, pow, sign } = Math;
 const rgb2oklab = (...args) => {
     // OKLab color space implementation taken from
     // https://bottosson.github.io/posts/oklab/
-    const [r, g, b] = unpack(args, 'rgb');
+    const [r, g, b, ...rest] = unpack(args, 'rgb');
     const [lr, lg, lb] = [
         rgb2lrgb(r / 255),
         rgb2lrgb(g / 255),
@@ -17,7 +17,8 @@ const rgb2oklab = (...args) => {
     return [
         0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
         1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
-        0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s
+        0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+        ...(rest.length > 0 && rest[0] < 1 ? [rest[0]] : [])
     ];
 };
 

--- a/src/io/oklch/rgb2oklch.js
+++ b/src/io/oklch/rgb2oklch.js
@@ -3,9 +3,10 @@ import rgb2oklab from '../oklab/rgb2oklab.js';
 import lab2lch from '../lch/lab2lch.js';
 
 const rgb2oklch = (...args) => {
-    const [r, g, b] = unpack(args, 'rgb');
+    const [r, g, b, ...rest] = unpack(args, 'rgb');
     const [l, a, b_] = rgb2oklab(r, g, b);
-    return lab2lch(l, a, b_);
+    const [L, c, h] = lab2lch(l, a, b_);
+    return [L, c, h, ...(rest.length > 0 && rest[0] < 1 ? [rest[0]] : [])];
 };
 
 export default rgb2oklch;

--- a/src/utils/unpack.js
+++ b/src/utils/unpack.js
@@ -13,5 +13,5 @@ export default (args, keyOrder = null) => {
     }
     // otherwise we just return the first argument
     // (which we suppose is an array of args)
-    return args[0];
+    return args[0].slice(0);
 };

--- a/test/alpha.test.js
+++ b/test/alpha.test.js
@@ -40,14 +40,14 @@ describe('Tests for the alpha channel', () => {
     });
 
     it('parsing rgba colors', () => {
-        const color = chroma.css('rgba(255,0,0,.3)');
+        const color = chroma.css('rgb(255 0 0 / 0.3)');
         expect(color.name()).toBe('red');
         expect(color.alpha()).toBe(0.3);
         expect(color.rgba()).toEqual([255, 0, 0, 0.3]);
     });
 
     it('parsing rgba colors (percentage)', () => {
-        const color = chroma.css('rgba(100%,0%,0%,0.2)');
+        const color = chroma.css('rgb(100% 0% 0% / 0.2)');
         expect(color.name()).toBe('red');
         expect(color.alpha()).toBe(0.2);
         expect(color.rgb()).toEqual([255, 0, 0]);
@@ -107,7 +107,7 @@ describe('Tests for the alpha channel', () => {
 
     it('rgba css output', () => {
         const color = chroma.css('hsla(0,100%,50%,0.25)');
-        expect(color.css()).toBe('rgba(255 0 0 / 0.25)');
+        expect(color.css()).toBe('rgb(255 0 0 / 0.25)');
     });
 
     it('hex output', () => {

--- a/test/alpha.test.js
+++ b/test/alpha.test.js
@@ -107,7 +107,7 @@ describe('Tests for the alpha channel', () => {
 
     it('rgba css output', () => {
         const color = chroma.css('hsla(0,100%,50%,0.25)');
-        expect(color.css()).toBe('rgba(255,0,0,0.25)');
+        expect(color.css()).toBe('rgba(255 0 0 / 0.25)');
     });
 
     it('hex output', () => {

--- a/test/autodetect.test.js
+++ b/test/autodetect.test.js
@@ -37,7 +37,7 @@ describe('autodetect color', () => {
 
     it('autodetect rgba color', () => {
         const result = chroma(255, 0, 0, 0.5);
-        expect(result.css()).toBe('rgba(255 0 0 / 0.5)');
+        expect(result.css()).toBe('rgb(255 0 0 / 0.5)');
     });
 
     it('autodetect legacy hsl color', () => {

--- a/test/autodetect.test.js
+++ b/test/autodetect.test.js
@@ -37,11 +37,16 @@ describe('autodetect color', () => {
 
     it('autodetect rgba color', () => {
         const result = chroma(255, 0, 0, 0.5);
-        expect(result.css()).toBe('rgba(255,0,0,0.5)');
+        expect(result.css()).toBe('rgba(255 0 0 / 0.5)');
     });
 
-    it('autodetect hsl color', () => {
+    it('autodetect legacy hsl color', () => {
         const result = chroma('hsl(120, 100%, 50%)');
+        expect(result.name()).toBe('lime');
+    });
+
+    it('autodetect modern hsl color', () => {
+        const result = chroma('hsl(120deg 100% 50%)');
         expect(result.name()).toBe('lime');
     });
 });

--- a/test/delta-e.test.js
+++ b/test/delta-e.test.js
@@ -20,7 +20,7 @@ describe('Testing delta-e color difference calculations', () => {
         const { in: input, out } = tests[key];
         it(key, () => {
             const result = deltaE(...input);
-            expect(result).toBeCloseTo(out, 6);
+            expect(result).toBeCloseTo(out, 4);
         });
     }
 });

--- a/test/io/css2rgb.test.js
+++ b/test/io/css2rgb.test.js
@@ -5,6 +5,15 @@ const css2rgb = chroma.input.format.css;
 
 describe('Testing CSS2RGB color conversions', () => {
     const testCases = {
+        // modern css colors
+        'rgb(0 0 0)': [0, 0, 0, 1],
+        'rgb(0% 0% 0%)': [0, 0, 0, 1],
+        'rgb(0% 100% 100%)': [0, 255, 255, 1],
+        'rgb(0% 100% 100% / 0.5)': [0, 255, 255, 0.5],
+        'rgb(0% 100% 100%/0.5)': [0, 255, 255, 0.5],
+        'rgba(0% 100% 100%/0.5)': [0, 255, 255, 0.5],
+
+        // legacy css colors
         'rgb(0,0,0)': [0, 0, 0, 1],
         'rgb(100%,100%,100%)': [255, 255, 255, 1],
         'foobarrgb(100%,100%,100%)': undefined,
@@ -16,6 +25,7 @@ describe('Testing CSS2RGB color conversions', () => {
         'hsl(60,100%,50%)': [255, 255, 0, 1],
         'hsla(180,100%,50%,1)': [0, 255, 255, 1],
         'hsla(300,100%,50%,.25)': [255, 0, 255, 0.25],
+        'rgba(32, 48, 96, 0.5)': [32, 48, 96, 0.5],
         blanchedalmond: [255, 235, 205, 1],
         blue: [0, 0, 255, 1],
         BlueViolet: [138, 43, 226, 1],

--- a/test/io/css2rgb.test.js
+++ b/test/io/css2rgb.test.js
@@ -30,7 +30,12 @@ describe('Testing CSS2RGB color conversions', () => {
         blue: [0, 0, 255, 1],
         BlueViolet: [138, 43, 226, 1],
         BROWN: [165, 42, 42, 1],
-        unknownColor: undefined
+        unknownColor: undefined,
+        'lab(47.99% -30.39 -8.98)': [0, 128, 128, 1],
+        'lab(47.99% -30.39 -8.98 / 0.25)': [0, 128, 128, 0.25],
+        'lab(47.99% -24.312% -7.13%)': [0, 128, 128, 1]
+        // 'oklab(92.83% -0.08 0.13)': [212, 248, 128, 1],
+        // 'oklab(92.83% -0.08 0.13 / 0.5)': [212, 248, 128, 0.5]
     };
 
     Object.keys(testCases).forEach((name) => {

--- a/test/io/lab2rgb.test.js
+++ b/test/io/lab2rgb.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import chroma from 'chroma-js';
 import lab2rgb from '../../src/io/lab/lab2rgb.js';
 import limit from '../../src/utils/limit.js';
 
@@ -27,5 +28,35 @@ describe('Testing LAB to RGB color conversions', () => {
         it(`${name}: should convert unpacked arguments ${lab} to ${rgb}`, () => {
             expect(lab2rgb(...lab).map(round)).toStrictEqual(rgb);
         });
+    });
+});
+
+describe('Test switching of Lab illuminant', () => {
+    it('defaults to D65', () => {
+        expect(chroma.lab(97.14, -21.55, 94.48).rgb()).toStrictEqual([
+            255, 255, 0
+        ]);
+    });
+
+    it('change to D50', () => {
+        expect(chroma.lab(97.14, -21.55, 94.48).rgb()).toStrictEqual([
+            255, 255, 0
+        ]);
+
+        chroma.setLabWhitePoint('d50');
+        // not D50 Lab yellow
+        expect(chroma.lab(97.14, -21.55, 94.48).rgb()).toStrictEqual([
+            243, 255, 0
+        ]);
+        // actual D50 Lab yellow
+        expect(chroma.lab(97.61, -15.75, 93.39).rgb()).toStrictEqual([
+            255, 255, 0
+        ]);
+
+        // change back to not mess up other tests
+        chroma.setLabWhitePoint('d65');
+        expect(chroma.lab(97.14, -21.55, 94.48).rgb()).toStrictEqual([
+            255, 255, 0
+        ]);
     });
 });

--- a/test/io/rgb2css.test.js
+++ b/test/io/rgb2css.test.js
@@ -16,6 +16,18 @@ const tests = {
         rgb: [255, 255, 0, 0.75],
         mode: 'hsl',
         css: 'hsl(60deg 100% 50% / 0.75)'
+    },
+    lab: { rgb: [255, 0, 0], mode: 'lab', css: 'lab(54.29% 80.81 69.89)' },
+    laba: {
+        rgb: [255, 0, 0, 0.5],
+        mode: 'lab',
+        css: 'lab(54.29% 80.81 69.89 / 0.5)'
+    },
+    lch: { rgb: [255, 0, 0], mode: 'lch', css: 'lch(54.29% 106.84 40.85deg)' },
+    lcha: {
+        rgb: [255, 0, 0, 0.25],
+        mode: 'lch',
+        css: 'lch(54.29% 106.84 40.85deg / 0.25)'
     }
 };
 

--- a/test/io/rgb2css.test.js
+++ b/test/io/rgb2css.test.js
@@ -2,24 +2,24 @@ import { describe, it, expect } from 'vitest';
 import rgb2css from '../../src/io/css/rgb2css.js';
 
 const tests = {
-    black: { rgb: [0, 0, 0], css: 'rgb(0,0,0)' },
-    red: { rgb: [255, 0, 0], css: 'rgb(255,0,0)' },
-    auto_rgba: { rgb: [255, 0, 0, 0.25], css: 'rgba(255,0,0,0.25)' },
-    force_rgba: { rgb: [255, 0, 0], mode: 'rgba', css: 'rgba(255,0,0,1)' },
-    hsl: { rgb: [255, 0, 0], mode: 'hsl', css: 'hsl(0,100%,50%)' },
+    black: { rgb: [0, 0, 0], css: 'rgb(0 0 0)' },
+    red: { rgb: [255, 0, 0], css: 'rgb(255 0 0)' },
+    auto_rgba: { rgb: [255, 0, 0, 0.25], css: 'rgb(255 0 0 / 0.25)' },
+    force_rgba: { rgb: [255, 0, 0], mode: 'rgba', css: 'rgb(255 0 0 / 1)' },
+    hsl: { rgb: [255, 0, 0], mode: 'hsl', css: 'hsl(0 100% 50%)' },
     auto_hsla: {
         rgb: [255, 0, 0, 0.5],
         mode: 'hsl',
-        css: 'hsla(0,100%,50%,0.5)'
+        css: 'hsl(0 100% 50% / 0.5)'
     },
     force_hsla: {
         rgb: [255, 255, 0, 0.75],
         mode: 'hsl',
-        css: 'hsla(60,100%,50%,0.75)'
+        css: 'hsl(60 100% 50% / 0.75)'
     }
 };
 
-describe('Testing rgb2css color conversions', () => {
+describe.only('Testing rgb2css color conversions', () => {
     Object.keys(tests).forEach((key) => {
         const { rgb, mode, css } = tests[key];
 

--- a/test/io/rgb2css.test.js
+++ b/test/io/rgb2css.test.js
@@ -6,16 +6,16 @@ const tests = {
     red: { rgb: [255, 0, 0], css: 'rgb(255 0 0)' },
     auto_rgba: { rgb: [255, 0, 0, 0.25], css: 'rgb(255 0 0 / 0.25)' },
     force_rgba: { rgb: [255, 0, 0], mode: 'rgba', css: 'rgb(255 0 0 / 1)' },
-    hsl: { rgb: [255, 0, 0], mode: 'hsl', css: 'hsl(0 100% 50%)' },
+    hsl: { rgb: [255, 0, 0], mode: 'hsl', css: 'hsl(0deg 100% 50%)' },
     auto_hsla: {
         rgb: [255, 0, 0, 0.5],
         mode: 'hsl',
-        css: 'hsl(0 100% 50% / 0.5)'
+        css: 'hsl(0deg 100% 50% / 0.5)'
     },
     force_hsla: {
         rgb: [255, 255, 0, 0.75],
         mode: 'hsl',
-        css: 'hsl(60 100% 50% / 0.75)'
+        css: 'hsl(60deg 100% 50% / 0.75)'
     }
 };
 

--- a/test/io/rgb2css.test.js
+++ b/test/io/rgb2css.test.js
@@ -28,6 +28,26 @@ const tests = {
         rgb: [255, 0, 0, 0.25],
         mode: 'lch',
         css: 'lch(54.29% 106.84 40.85deg / 0.25)'
+    },
+    oklab: {
+        rgb: [212, 248, 128],
+        mode: 'oklab',
+        css: 'oklab(92.83% -0.08 0.13)'
+    },
+    oklaba: {
+        rgb: [212, 248, 128, 0.4],
+        mode: 'oklab',
+        css: 'oklab(92.83% -0.08 0.13 / 0.4)'
+    },
+    oklch: {
+        rgb: [212, 248, 128],
+        mode: 'oklch',
+        css: 'oklch(92.83% 0.15 123.13deg)'
+    },
+    oklcha: {
+        rgb: [212, 248, 128, 0.6],
+        mode: 'oklch',
+        css: 'oklch(92.83% 0.15 123.13deg / 0.6)'
     }
 };
 

--- a/test/io/rgb2lab.test.js
+++ b/test/io/rgb2lab.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import rgb2lab from '../../src/io/lab/rgb2lab.js';
+import chroma from 'chroma-js';
 
 const round = (digits) => {
     const d = Math.pow(10, digits);
@@ -38,5 +39,22 @@ describe('Test rgb2lab color conversions', () => {
         it(`rgb2lab ${key} converts arguments`, () => {
             expect(rgb2lab(...rgb).map(rnd)).toEqual(lab);
         });
+    });
+});
+
+describe('Test switching of Lab illuminant', () => {
+    it('defaults to D65', () => {
+        expect(chroma('yellow').lab().map(rnd)).toStrictEqual([
+            97.14, -21.55, 94.48
+        ]);
+    });
+
+    it('change to D50', () => {
+        expect(chroma('yellow').lab().map(rnd)).toEqual([97.14, -21.55, 94.48]);
+        chroma.setLabWhitePoint('d50');
+        expect(chroma('yellow').lab().map(rnd)).toEqual([97.61, -15.75, 93.39]);
+        // change back to not mess up other tests
+        chroma.setLabWhitePoint('d65');
+        expect(chroma('yellow').lab().map(rnd)).toEqual([97.14, -21.55, 94.48]);
     });
 });

--- a/test/scales.test.js
+++ b/test/scales.test.js
@@ -249,7 +249,7 @@ describe('Some tests for scale()', () => {
         const color = scale('YlGnBu')(0.3).alpha(0.675).css();
 
         it('dont round alpha value', () => {
-            expect(color).toBe('rgba(170 222 183 / 0.675)');
+            expect(color).toBe('rgb(170 222 183 / 0.675)');
         });
     });
 

--- a/test/scales.test.js
+++ b/test/scales.test.js
@@ -241,7 +241,7 @@ describe('Some tests for scale()', () => {
         const color = scale('YlGnBu')(0.3).css();
 
         it('have rounded rgb() values', () => {
-            expect(color).toBe('rgb(170,222,183)');
+            expect(color).toBe('rgb(170 222 183)');
         });
     });
 
@@ -249,7 +249,7 @@ describe('Some tests for scale()', () => {
         const color = scale('YlGnBu')(0.3).alpha(0.675).css();
 
         it('dont round alpha value', () => {
-            expect(color).toBe('rgba(170,222,183,0.675)');
+            expect(color).toBe('rgba(170 222 183 / 0.675)');
         });
     });
 
@@ -265,7 +265,7 @@ describe('Some tests for scale()', () => {
         });
 
         it('three css colors', () => {
-            expect(f.colors(3, 'css')).toEqual(['rgb(255,255,0)', 'rgb(128,178,0)', 'rgb(0,100,0)']);
+            expect(f.colors(3, 'css')).toEqual(['rgb(255 255 0)', 'rgb(128 178 0)', 'rgb(0 100 0)']);
         });
     });
 
@@ -281,7 +281,7 @@ describe('Some tests for scale()', () => {
         });
 
         it('three css colors', () => {
-            expect(f.colors(3, 'css')).toEqual(['rgb(255,255,0)', 'rgb(128,178,0)', 'rgb(0,100,0)']);
+            expect(f.colors(3, 'css')).toEqual(['rgb(255 255 0)', 'rgb(128 178 0)', 'rgb(0 100 0)']);
         });
     });
 


### PR DESCRIPTION
CSS now supports a modern syntax and the one currently implemented in chroma.js is rebranded as "legacy". So we should go with the times and change the default output of `color.css()` to the modern syntax.

Since this is a breaking change I think we should bump the version number to 3.

This branch will also add support for Lab, Lch, OkLab, and OkLch CSS exports, e.g.

```js
chroma('hotpink').css('oklab');
```

- [x] support configuration of Lab white reference illuminant to match W3C implementation of Lab
- [x] document new methods `getLabWhitePoint` and `setLabWhitePoint`
- [x] support `.css('lab')`
- [x] support `.css('lch')`
- [x] support `.css('oklab')`
- [x] support `.css('oklch')`
- [x] support parsing of modern CSS colors in rgb() space
- [x] support parsing of modern CSS colors in hsl() space
- [x] document new CSS color exporting 
- [x] support highlighting of modern CSS color in documentation
- [x] support parsing of modern CSS colors in lab() space
- [ ] support parsing of modern CSS colors in lch() space
- [ ] support parsing of modern CSS colors in oklab() space
- [ ] support parsing of modern CSS colors in oklch() space
