### PR TITLE
fix: repair non-default imports

### DIFF
--- a/index-light.js
+++ b/index-light.js
@@ -24,11 +24,20 @@ import './src/interpolator/lrgb.js';
 import './src/interpolator/oklab.js';
 
 // generators -- > create new colors
-import mix from './src/generator/mix';
-chroma.mix = chroma.interpolate = mix;
+import mix from './src/generator/mix.js';
 
 // other utility methods
-import valid from './src/utils/valid';
-chroma.valid = valid;
+import valid from './src/utils/valid.js';
+
+import Color from './src/Color.js';
+
+Object.assign(chroma, {
+    Color,
+    valid,
+    mix,
+    interpolate: mix
+});
 
 export default chroma;
+
+export { Color, valid, mix, mix as interpolate };

--- a/index.js
+++ b/index.js
@@ -70,26 +70,50 @@ import scales from './src/utils/scales.js';
 // colors
 import colors from './src/colors/w3cx11.js';
 import brewer from './src/colors/colorbrewer.js';
+import Color from './src/Color.js';
 
 Object.assign(chroma, {
+    analyze,
     average,
     bezier,
     blend,
-    cubehelix,
-    mix,
-    interpolate: mix,
-    random,
-    scale,
-    analyze,
+    brewer,
+    Color,
+    colors,
     contrast,
+    cubehelix,
     deltaE,
     distance,
-    limits,
-    valid,
-    scales,
     input,
-    colors,
-    brewer
+    interpolate: mix,
+    limits,
+    mix,
+    random,
+    scale,
+    scales,
+    valid
 });
 
 export default chroma;
+
+export {
+    analyze,
+    average,
+    bezier,
+    blend,
+    brewer,
+    Color,
+    colors,
+    contrast,
+    cubehelix,
+    deltaE,
+    distance,
+    input,
+    limits,
+    mix,
+    mix as interpolate,
+    random,
+    scale,
+    scales,
+    valid
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     ".": {
       "import": "./index.js",
       "require": "./dist/chroma.cjs"
+    },
+    "./light": {
+      "import": "./index-light.js",
+      "require": "./dist/chroma-light.cjs"
     }
   },
   "main": "./index.js",

--- a/src/chroma.js
+++ b/src/chroma.js
@@ -2,10 +2,9 @@ import Color from './Color.js';
 import { version } from './version.js';
 
 const chroma = (...args) => {
-    return new chroma.Color(...args);
+    return new Color(...args);
 };
 
-chroma.Color = Color;
 chroma.version = version;
 
 export default chroma;


### PR DESCRIPTION
resolves #346

this allows users to import chroma.js both as default package, e.g.

```js
import chroma from 'chroma-js';
```

or to import individual methods

```js
import { average } from 'chroma-js';
average(['red', 'green']).hex()
```

