### PR TITLE
Add missing index-light.js

### DIFF
--- a/index-light.js
+++ b/index-light.js
@@ -1,0 +1,43 @@
+import chroma from './src/chroma.js';
+
+// feel free to comment out anything to rollup
+// a smaller chroma.js built
+
+// io --> convert colors
+import './src/io/css/index.js';
+import './src/io/hex/index.js';
+import './src/io/hsl/index.js';
+import './src/io/lab/index.js';
+import './src/io/oklab/index.js';
+import './src/io/rgb/index.js';
+
+// operators --> modify existing Colors
+import './src/ops/alpha.js';
+import './src/ops/darken.js';
+import './src/ops/get.js';
+import './src/ops/mix.js';
+import './src/ops/set.js';
+import './src/ops/shade.js';
+
+// interpolators
+import './src/interpolator/lrgb.js';
+import './src/interpolator/oklab.js';
+
+// generators -- > create new colors
+import mix from './src/generator/mix.js';
+
+// other utility methods
+import valid from './src/utils/valid.js';
+
+import Color from './src/Color.js';
+
+Object.assign(chroma, {
+    Color,
+    valid,
+    mix,
+    interpolate: mix
+});
+
+export default chroma;
+
+export { Color, valid, mix, mix as interpolate };


### PR DESCRIPTION
`index-light.js` file got removed in https://github.com/gka/chroma.js/commit/43847f52d87c452937210698baaba6e4429b809a#diff-897dfa6243e488eb651b275ae221e8e7710a6ce5a5e8814d2f73283b76c471dc

This seems was done by mistake, because it's still referenced at https://github.com/gka/chroma.js/blob/main/package.json#L30. Due to this, importing light bundle in ESM fails on missing file.