### PR TITLE
Allow importing files from src directory in ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     },
     "./src/utils/*.js": {
       "import": "./src/utils/*.js"
+    },
+    "./src/*.js": {
+      "import": "./src/*.js"
     }
   },
   "main": "./index.js",


### PR DESCRIPTION
This is especially for `src/Color.js` which is the main necessary entry-point for building a custom bundle