### PR TITLE
fix(scale): recompute classes() breaks when domain() changes

### DIFF
--- a/.changeset/scale-classes-domain-order.md
+++ b/.changeset/scale-classes-domain-order.md
@@ -1,0 +1,5 @@
+---
+'chroma-js': patch
+---
+
+scale.classes(count) now recomputes its breaks against the scale domain, so calling classes() before domain() gives the same result as calling them in the reverse order

--- a/src/generator/scale.js
+++ b/src/generator/scale.js
@@ -17,6 +17,7 @@ export default function (colors) {
     let _pos = [];
     let _padding = [0, 0];
     let _classes = false;
+    let _classCount = null;
     let _colors = [];
     let _out = false;
     let _min = 0;
@@ -177,18 +178,23 @@ export default function (colors) {
         }
     };
 
+    const computeClasses = function (count) {
+        const d = chroma.analyze(_positions);
+        if (count === 0) {
+            return [d.min, d.max];
+        }
+        return chroma.limits(d, 'e', count);
+    };
+
     f.classes = function (classes) {
         if (classes != null) {
             if (type(classes) === 'array') {
                 _classes = classes;
+                _classCount = null;
                 _positions = [classes[0], classes[classes.length - 1]];
             } else {
-                const d = chroma.analyze(_positions);
-                if (classes === 0) {
-                    _classes = [d.min, d.max];
-                } else {
-                    _classes = chroma.limits(d, 'e', classes);
-                }
+                _classCount = classes;
+                _classes = computeClasses(classes);
             }
             return f;
         }
@@ -233,6 +239,9 @@ export default function (colors) {
             }
         }
         _positions = [_min, _max];
+        if (_classCount != null) {
+            _classes = computeClasses(_classCount);
+        }
         return f;
     };
 

--- a/test/scales.test.js
+++ b/test/scales.test.js
@@ -430,4 +430,17 @@ describe('Some tests for scale()', () => {
             expect(f(100).hex()).toBe('#000000');
         });
     });
+
+    describe('classes() before domain() yields same result as domain() before classes()', () => {
+        const a = scale(['black', 'white']).domain([-2, 2]).classes(5);
+        const b = scale(['black', 'white']).classes(5).domain([-2, 2]);
+
+        it('produces matching colors', () => {
+            expect(b.colors(5, 'hex')).toEqual(a.colors(5, 'hex'));
+        });
+
+        it('recomputes class breaks against the domain', () => {
+            expect(b.classes()).toEqual(a.classes());
+        });
+    });
 });


### PR DESCRIPTION
Calling `scale().classes(n)` before `.domain([min,max])` computed class breaks against the default `[0,1]` range, so the result differed from the reverse call order. `.domain()` now recomputes the breaks when classes were requested as a count. Closes #371.