### PR TITLE
fix: preserve alpha when interpolating in oklch

### DIFF
--- a/.changeset/oklch-mix-alpha.md
+++ b/.changeset/oklch-mix-alpha.md
@@ -1,0 +1,5 @@
+---
+'chroma-js': patch
+---
+
+fix: preserve alpha when interpolating in oklch

--- a/src/interpolator/_hsx.js
+++ b/src/interpolator/_hsx.js
@@ -1,4 +1,5 @@
 import Color from '../Color.js';
+import { reverse3 } from '../utils/index.js';
 
 export default (col1, col2, f, m) => {
     let xyz0, xyz1;
@@ -19,8 +20,8 @@ export default (col1, col2, f, m) => {
         xyz0 = col1.hcl();
         xyz1 = col2.hcl();
     } else if (m === 'oklch') {
-        xyz0 = col1.oklch().reverse();
-        xyz1 = col2.oklch().reverse();
+        xyz0 = reverse3(col1.oklch());
+        xyz1 = reverse3(col2.oklch());
     }
 
     let hue0, hue1, sat0, sat1, lbv0, lbv1;

--- a/test/mix.test.js
+++ b/test/mix.test.js
@@ -100,4 +100,13 @@ describe('Some tests for chroma.color()', () => {
         expect(result.hex()).toBe('#34343480');
         expect(result.css()).toBe('rgb(52 52 52 / 0.5)');
     });
+
+    it('mix transparent color in oklch', () => {
+        // alpha on an input must not change the interpolated L, C and H,
+        // only the alpha channel. So the rgb part has to match the opaque mix.
+        const opaque = chroma.mix('#ff0000', '#0000ff', 0.5, 'oklch');
+        const transparent = chroma.mix('#ff000080', '#0000ff', 0.5, 'oklch');
+        expect(transparent.hex('rgb')).toBe(opaque.hex('rgb'));
+        expect(transparent.hex()).toBe('#ba00c2bf');
+    });
 });


### PR DESCRIPTION
The shared hue interpolator in `src/interpolator/_hsx.js` reverses the polar color so the hue ends up at index 0 for the hue-blending math. For `oklch` it does that with `Array.prototype.reverse()`:

```js
xyz0 = col1.oklch().reverse();
xyz1 = col2.oklch().reverse();
```

`rgb2oklch` appends the alpha channel when it is below 1, so `oklch()` returns `[L, c, h, a]` for a semi-transparent color. `reverse()` flips the whole array to `[a, h, c, L]`, and the next line `[hue0, sat0, lbv0] = xyz0` then reads alpha as the hue, hue as the chroma and chroma as the lightness. So any `oklch` interpolation/mix where an input has alpha < 1 comes out wrong.

The `hcl` branch right above it does not have this problem: `Color.prototype.hcl` was switched to `reverse3` (in 27a2bb3, resolving #359), which only reverses the first three components and leaves alpha in place. The `oklch` branch was left on the old `reverse()`. This change uses the same `reverse3` helper there.

Mixing a half-transparent red with blue, the rgb part should match the opaque mix (only the alpha channel should differ):

```js
// before
chroma.mix('#ff000080', '#0000ff', 0.5, 'oklch').hex('rgb') // '#ff00ff'  (wrong)
chroma.mix('#ff0000',   '#0000ff', 0.5, 'oklch').hex('rgb') // '#ba00c2'  (opaque, correct)

// after
chroma.mix('#ff000080', '#0000ff', 0.5, 'oklch').hex('rgb') // '#ba00c2'
chroma.mix('#ff000080', '#0000ff', 0.5, 'oklch').hex()      // '#ba00c2bf'
```

Added a regression test in `test/mix.test.js` and a changeset. The full suite passes.
