### PR TITLE
fix(scale): clamp out-of-domain input before applying gamma

### DIFF
--- a/src/generator/scale.js
+++ b/src/generator/scale.js
@@ -117,7 +117,9 @@ export default function (colors) {
         }
 
         if (_gamma !== 1) {
-            t = pow(t, _gamma);
+            // clamp before pow: a fractional gamma over a negative base returns
+            // NaN, so out-of-domain values must be pinned to the endpoints first
+            t = pow(limit(t, 0, 1), _gamma);
         }
 
         t = _padding[0] + t * (1 - _padding[0] - _padding[1]);

--- a/test/scales.test.js
+++ b/test/scales.test.js
@@ -430,4 +430,18 @@ describe('Some tests for scale()', () => {
             expect(f(100).hex()).toBe('#000000');
         });
     });
+
+    describe('gamma scale with out-of-domain input', () => {
+        const f = scale('YlGn').domain([5, 15]).gamma(1.2);
+
+        it('clamps below domain to left endpoint', () => {
+            expect(f(4).hex()).toBe('#ffffe5');
+            expect(f(4).hex()).toBe(f(5).hex());
+        });
+
+        it('clamps above domain to right endpoint', () => {
+            expect(f(16).hex()).toBe('#004529');
+            expect(f(16).hex()).toBe(f(15).hex());
+        });
+    });
 });


### PR DESCRIPTION
Fixes #331.

`chroma.scale('YlGn').domain([5,15]).gamma(1.2)(4)` throws instead of clamping the out-of-domain value. With a fractional gamma, `pow(t, _gamma)` runs while `t` is still negative (`t` is -0.1 for input 4), and `Math.pow(-0.1, 1.2)` is NaN, which falls through to an invalid color. The `limit(t, 0, 1)` a few lines down handles the no-gamma path, but the gamma branch has already produced NaN by then.

The fix clamps `t` into [0,1] before the pow, reusing the `limit` helper that's already imported. Out-of-domain input now pins to the nearest endpoint, same as it does without a gamma. This matches @regorxxx's fork fix you said you'd look at, just using `limit` instead of an explicit if/else.

One call worth your eye: `limit` also clamps the high side, so an above-max input sits at the padded endpoint rather than the hard edge. With default padding that's identical to before and the full suite stays green, but if you'd rather scope the change strictly to the negative side that broke, `pow(t < 0 ? 0 : t, _gamma)` does only that.

Test in `test/scales.test.js` covers both ends. The below-domain case throws on `main` and passes with the fix.
