### PR TITLE
fix(hsl): keep alpha when constructing from an object

### DIFF
--- a/src/io/hsl/hsl2rgb.js
+++ b/src/io/hsl/hsl2rgb.js
@@ -1,7 +1,7 @@
 import { unpack } from '../../utils/index.js';
 
 const hsl2rgb = (...args) => {
-    args = unpack(args, 'hsl');
+    args = unpack(args, 'hsla');
     const [h, s, l] = args;
     let r, g, b;
     if (s === 0) {

--- a/test/alpha.test.js
+++ b/test/alpha.test.js
@@ -68,6 +68,12 @@ describe('Tests for the alpha channel', () => {
         expect(color.alpha()).toBe(0.25);
     });
 
+    it('constructing hsla color from object keeps alpha (#219)', () => {
+        const color = chroma({ h: 120, s: 0.8, l: 0.75, a: 0.5 });
+        expect(color.alpha()).toBe(0.5);
+        expect(color.rgba()).toEqual([140, 242, 140, 0.5]);
+    });
+
     it('constructing hsva color', () => {
         const color = chroma(0, 1, 1, 0.25, 'hsv');
         expect(color.name()).toBe('red');


### PR DESCRIPTION
## Problem

`chroma({ h, s, l, a })` dropped the alpha channel and returned an opaque color, while the equivalent rgb object form kept it. `hsl2rgb` already preserves alpha for array/positional input via its `args.length > 3` branch, but it unpacked objects with the keyOrder `'hsl'`, which excludes the `a` key.

## Fix

Unpack with `'hsla'` (the same keyOrder `css/hsl2css.js` already uses) so object input reaches the existing alpha-preserving path. Array and positional callers are unaffected since `unpack` ignores keyOrder when given 3+ args or an array.

```diff
-    args = unpack(args, 'hsl');
+    args = unpack(args, 'hsla');
```

## Testing

Added a regression test in `test/alpha.test.js`:

```js
it('constructing hsla color from object keeps alpha (#219)', () => {
    const color = chroma({ h: 120, s: 0.8, l: 0.75, a: 0.5 });
    expect(color.alpha()).toBe(0.5);
    expect(color.rgba()).toEqual([140, 242, 140, 0.5]);
});
```

Closes #219
