### PR TITLE
fix: count k-means cluster sizes once per point

### DIFF
--- a/.changeset/kmeans-cluster-sizes.md
+++ b/.changeset/kmeans-cluster-sizes.md
@@ -1,0 +1,5 @@
+---
+"chroma-js": patch
+---
+
+Fix `chroma.limits(data, 'k', n)` (k-means) dropping clusters. The cluster tally was incremented inside the nearest-centroid loop, so each point was counted up to `n` times against intermediate best-so-far indices, corrupting the centroid means. It is now counted once per point after the argmin, so well-separated data yields the expected breaks (`chroma.limits([0,1,2,50,51,52,100,101,102], 'k', 3)` returns `[0, 2, 52, 102]`).

--- a/src/utils/analyze.js
+++ b/src/utils/analyze.js
@@ -124,9 +124,11 @@ export function limits(data, mode = 'equal', num = 7) {
                         mindist = dist;
                         best = j;
                     }
-                    clusterSizes[best]++;
-                    assignments[i] = best;
                 }
+                // tally the winning cluster once per point, after the argmin
+                // over j; incrementing inside the loop corrupted clusterSizes
+                clusterSizes[best]++;
+                assignments[i] = best;
             }
 
             // update centroids step

--- a/test/limits.test.js
+++ b/test/limits.test.js
@@ -54,4 +54,10 @@ describe('Some tests for chroma.limits()', () => {
     it('logarithmic domain - non-positive values', () => {
         expect(() => limits([-1, 10000], 'log', 4)).toThrow('Logarithmic scales are only possible for values > 0');
     });
+
+    it('k-means classifies all requested clusters', () => {
+        // three well-separated clusters must yield three class breaks; a
+        // corrupted cluster-size tally previously dropped the middle cluster
+        expect(limits([0, 1, 2, 50, 51, 52, 100, 101, 102], 'k', 3)).toEqual([0, 2, 52, 102]);
+    });
 });


### PR DESCRIPTION
## What

`chroma.limits(data, 'k', n)` (k-means classification) computes wrong class breaks:

```js
chroma.limits([0, 1, 2, 50, 51, 52, 100, 101, 102], 'k', 3)
// actual:   [0, 2, 102]      -> only two non-empty classes; {50,51,52} is dropped
// expected: [0, 2, 52, 102]  -> the three natural clusters
```

In the assignment step, `clusterSizes[best]++` and `assignments[i] = best` are **inside** the inner nearest-centroid loop (`for (let j = 0; j < num; j++)`), so for each point the tally is incremented up to `num` times using the intermediate best-so-far index. The centroid-update step then does `newCentroids[j] *= 1 / clusterSizes[j]`, dividing each cluster's value-sum by a corrupted count, so the "centroids" are not the cluster means and k-means converges to wrong clusters. Across 200 random datasets the output differs from correct 1-D k-means on ~168.

## Fix

Move the tally and assignment out of the inner loop, so the winning cluster is counted exactly once per point after the argmin over `j`. `newCentroids[j] = sum / clusterSizes[j]` is then the true cluster mean.

## Tests

Added a `limits()` case asserting three well-separated clusters yield `[0, 2, 52, 102]`. Fails on `main`, passes with the fix. Full suite green (`2520/2520`), prettier + eslint clean.
