### PR TITLE
fix(hsv): name rgb2hsv converter correctly

### DIFF
--- a/src/io/hsv/rgb2hsv.js
+++ b/src/io/hsv/rgb2hsv.js
@@ -7,7 +7,7 @@ const { min, max } = Math;
  * - rgb2hsv([r,g,b])
  * - rgb2hsv({r,g,b})
  */
-const rgb2hsl = (...args) => {
+const rgb2hsv = (...args) => {
     args = unpack(args, 'rgb');
     let [r, g, b] = args;
     const min_ = min(r, g, b);
@@ -29,4 +29,4 @@ const rgb2hsl = (...args) => {
     return [h, s, v];
 };
 
-export default rgb2hsl;
+export default rgb2hsv;


### PR DESCRIPTION
## What changed

Rename the internal converter function in `src/io/hsv/rgb2hsv.js` from `rgb2hsl` to `rgb2hsv`.

## Why

The file implements and exports RGB-to-HSV conversion, but the local function name still said `rgb2hsl`. This is confusing when reading stack traces, debugging, or navigating the source, and it was reported in #363.

Fixes #363

## Validation

- `npm test -- test/io/rgb2hsv.test.js --run`
- pre-commit ran `npm run lint` and full `npm test` successfully: 50 test files, 2519 tests
