### PR TITLE
fix(rgb): reject non-numeric channels

### DIFF
--- a/src/io/rgb/index.js
+++ b/src/io/rgb/index.js
@@ -18,8 +18,17 @@ Color.prototype.rgba = function (rnd = true) {
 const rgb = (...args) => new Color(...args, 'rgb');
 Object.assign(chroma, { rgb });
 
+const isValidChannel = (value) =>
+    type(value) === 'number' && !Number.isNaN(value);
+
 input.format.rgb = (...args) => {
     const rgba = unpack(args, 'rgba');
+    if (!rgba.slice(0, 3).every(isValidChannel)) {
+        throw new Error('invalid rgb color');
+    }
+    if (rgba[3] !== undefined && !isValidChannel(rgba[3])) {
+        throw new Error('invalid rgb color');
+    }
     if (rgba[3] === undefined) rgba[3] = 1;
     return rgba;
 };
@@ -30,6 +39,7 @@ input.autodetect.push({
         args = unpack(args, 'rgba');
         if (
             type(args) === 'array' &&
+            args.slice(0, 3).every(isValidChannel) &&
             (args.length === 3 ||
                 (args.length === 4 &&
                     type(args[3]) == 'number' &&

--- a/test/autodetect.test.js
+++ b/test/autodetect.test.js
@@ -35,6 +35,16 @@ describe('autodetect color', () => {
         expect(result.hex()).toBe('#0000ff');
     });
 
+    it('rejects non-numeric RGB channels', () => {
+        expect(() => chroma('nonsense', 0, 255, 'rgb')).toThrow('invalid rgb color');
+        expect(() => chroma(null, 0, 255, 'rgb')).toThrow('invalid rgb color');
+    });
+
+    it('still clips out-of-range numeric RGB channels', () => {
+        expect(chroma(-1000, 0, 255, 'rgb').hex()).toBe('#0000ff');
+        expect(chroma(1000, 0, 255, 'rgb').hex()).toBe('#ff00ff');
+    });
+
     it('autodetect rgba color', () => {
         const result = chroma(255, 0, 0, 0.5);
         expect(result.css()).toBe('rgb(255 0 0 / 0.5)');


### PR DESCRIPTION
## What changed

Reject non-numeric channels passed through explicit RGB mode instead of silently converting them to `0`.

## Why

As discussed in #356, clipping out-of-range numeric channels is intentional, but nonsensical values such as strings or `null` should not be accepted as RGB channels. This keeps numeric clipping intact while making invalid RGB input fail clearly.

Fixes #356

## Validation

- `npm test -- test/autodetect.test.js --run`
- pre-commit ran `npm run lint` and full `npm test` successfully: 50 test files, 2521 tests
