### PR TITLE
Fix hcl/lch/oklch interpolation not reaching pure black/white exactly

### DIFF
--- a/.changeset/hcl-oklch-reach-black.md
+++ b/.changeset/hcl-oklch-reach-black.md
@@ -1,0 +1,5 @@
+---
+'chroma-js': patch
+---
+
+Fix hcl/lch/oklch interpolation not reaching pure black/white exactly when interpolating from a saturated color

--- a/src/interpolator/_hsx.js
+++ b/src/interpolator/_hsx.js
@@ -43,10 +43,15 @@ export default (col1, col2, f, m) => {
         hue = hue0 + f * dh;
     } else if (!isNaN(hue0)) {
         hue = hue0;
-        if ((lbv1 == 1 || lbv1 == 0) && m != 'hsv') sat = sat0;
+        // Freezing saturation at sat0 keeps colors looking vivid while
+        // shading/tinting toward an achromatic endpoint (e.g. shade(0.5)).
+        // But once f fully reaches that endpoint (f === 1), the result must
+        // equal it exactly, so the freeze has to stop there and fall through
+        // to the normal interpolation, which resolves to sat1 (see #310).
+        if (f < 1 && (lbv1 == 1 || lbv1 == 0) && m != 'hsv') sat = sat0;
     } else if (!isNaN(hue1)) {
         hue = hue1;
-        if ((lbv0 == 1 || lbv0 == 0) && m != 'hsv') sat = sat1;
+        if (f > 0 && (lbv0 == 1 || lbv0 == 0) && m != 'hsv') sat = sat1;
     } else {
         hue = Number.NaN;
     }

--- a/test/mix.test.js
+++ b/test/mix.test.js
@@ -95,6 +95,24 @@ describe('Some tests for chroma.color()', () => {
         expect(result.css()).toBe('rgb(52 52 52)');
     });
 
+    it('hcl/lch interpolation reaches pure black exactly, even from a saturated color (#310)', () => {
+        expect(chroma.interpolate('#f00', '#000', 1, 'hcl').hex()).toBe('#000000');
+        expect(chroma.interpolate('#f00', '#000', 1, 'lch').hex()).toBe('#000000');
+        expect(chroma.interpolate('#ccc', '#000', 1, 'hcl').hex()).toBe('#000000');
+        // a target that is only *almost* black should still work as before
+        expect(chroma.interpolate('#f00', '#010101', 1, 'hcl').hex()).toBe('#010101');
+    });
+
+    it('oklch interpolation reaches pure black exactly, even from a saturated color (#310)', () => {
+        expect(chroma.interpolate('#f00', '#000', 1, 'oklch').hex()).toBe('#000000');
+    });
+
+    it('hcl shading toward black still stays vivid at intermediate steps', () => {
+        // the fix for #310 only applies exactly at f === 1; intermediate
+        // steps must keep behaving as before (shade()/tint() rely on this)
+        expect(chroma('red').shade(0.5, 'lch').hex()).toBe('#a60000');
+    });
+
     it('mix transparent gray and black', () => {
         const result = chroma.mix('#66666600', '#000000', 0.5, 'lch');
         expect(result.hex()).toBe('#34343480');


### PR DESCRIPTION
## Summary

Fixes #310.

```js
chroma.interpolate('#f00', '#000', 1, 'hcl').hex(); // '#5b0000', should be '#000000'
```

`interpolator/_hsx.js` intentionally freezes saturation/chroma at the colored endpoint's value while interpolating toward (or from) an achromatic color, so `shade()`/`tint()` keep colors looking vivid instead of fading to gray at intermediate steps. That freeze is correct and tested behavior for `f` strictly between 0 and 1.

The bug is that the freeze also applied exactly at the boundary (`f === 1` interpolating toward black/white, or `f === 0` interpolating away from it), where the result must equal the achromatic endpoint exactly. Unlike hsl/hsv/hcg/hsi (where saturation has no visual effect at extreme lightness/value), chroma in hcl/lch/oklch is still meaningful at L=0, so freezing it at a large nonzero value there produces a slightly-off-black/white color once converted to RGB.

## Fix

Stop the freeze exactly at that boundary (`f < 1` / `f > 0` guards) so it falls through to the existing linear interpolation, which already resolves correctly to the target's own chroma (0 for a fully achromatic target). Every other case is untouched.

## Test plan

- Added tests in `test/mix.test.js`:
  - the exact cases from the issue (`hcl`/`lch`/`oklch` reaching pure black from a saturated color),
  - a near-black target to confirm non-degenerate targets still resolve exactly,
  - `red.shade(0.5, 'lch')` to lock in that the intermediate-step "stay vivid" behavior is unchanged.
- Verified the regression: reverting the source change turns the two new boundary tests from passing into failing with `'#5b0000'` / `'#100000'` (the exact wrong values from the issue), while the shade test still passes on the reverted code — confirming the test isolates the actual bug rather than the intentional shading behavior.
- Full suite passes locally: `npx vitest run` — 2522 passing (2519 existing + 3 new).
- `npm run lint` (prettier + eslint) passes, and the repo's pre-commit hook (lint + full test run) passed on commit.